### PR TITLE
Sonar: Remove this unused import. (rule kotlin:S1128)

### DIFF
--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandJenkinsTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandJenkinsTest.kt
@@ -11,7 +11,45 @@ import io.kotest.extensions.system.SystemEnvironmentTestListener
 import io.kotest.matchers.comparables.shouldBeEqualComparingTo
 import io.kotest.matchers.string.shouldContainIgnoringCase
 import io.micronaut.configuration.picocli.PicocliRunner
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import de.deutschepost.sdm.cdlib.names.git.GitRepository
+import de.deutschepost.sdm.cdlib.names.git.GitRevision
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.SystemEnvironmentTestListener
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.micronaut.configuration.picocli.PicocliRunner
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import org.eclipse.jgit.lib.Repository
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
+class NamesCommandJenkinsTest : AnnotationSpec() {
+
+    override fun listeners() = listOf(
+        SystemEnvironmentTestListener(
+            mapOf(
+                "JOB_NAME" to "SDM/cli/i593-cli-createnames",
+                "BRANCH_NAME" to "i593-cli-createnames",
+                "GIT_BRANCH" to "i593-cli-createnames",
+                "BUILD_NUMBER" to "25",
+                "GIT_COMMIT" to "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
+                "JOB_URL" to "https://jenkins.dhl.com/job/SDM/job/cli/job/i613-record-webapproval/",
+                "RUN_DISPLAY_URL" to "https://jenkins.dhl.com/job/SDM/job/cli/job/i613-record-webapproval/26/display/redirect",
+                "JOB_DISPLAY_URL" to "https://jenkins.dhl.com/job/SDM/job/cli/job/i613-record-webapproval",
+                // Explicit set / reset var. relevant for platform detection
+                "JENKINS_HOME" to "/var/lib/jenkins",
+                "TF_BUILD" to "",
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>While it’s not difficult to remove these unneeded lines manually, modern code editors support the removal of every unnecessary import with a single
click from every file of the project.</p>

<h4>Noncompliant code example</h4>
<pre data-diff-id="1" data-diff-type="noncompliant">
package myapp.helpers

import java.io.IOException
import java.nio.file.*
import java.nio.file.*     // Noncompliant - package is imported twice
import java.nio.*          // Noncompliant - nothing is used from that package

object FileHelper {
    fun readFirstLine(filePath: String)
        = Files.readAllLines(Paths.get(filePath)).first()
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
package myapp.helpers

import java.io.IOException
import java.nio.file.*

object FileHelper {
    fun readFirstLine(filePath: String)
        = Files.readAllLines(Paths.get(filePath)).first()
}
</pre>
<p>Unnecessary imports refer to importing types that are not used or referenced anywhere in the code.</p>
<p>Although they don’t affect the runtime behavior of the application after compilation, removing them will:</p>
<ul>
  <li> Improve the readability and maintainability of the code. </li>
  <li> Help avoid potential naming conflicts. </li>
  <li> Improve the build time, as the compiler has fewer lines to read and fewer types to resolve. </li>
  <li> Reduce the number of items the code editor will show for auto-completion, thereby showing fewer irrelevant suggestions. </li>
</ul>
<h3>Exceptions</h3>
<p>Imports for types mentioned in KDoc are ignored.</p>

### These files were changed in the pull request:
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandJenkinsTest.kt
