### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -248,7 +248,7 @@ class ChangeHandler(
     }
 
     fun preauthorize(): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_REQUIRED_CHANGE_INFORMATION }
         logger.info { "Determining whether change can be preauthorized." }
         val changeType = determineChangeType()
         logTypeResults(changeType)
@@ -265,7 +265,7 @@ class ChangeHandler(
 
     fun resume(): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_REQUIRED_CHANGE_INFORMATION }
 
         logger.info { "Resuming change: ${change.self}" }
         logger.info { "Adding resume comment to change..." }
@@ -286,7 +286,7 @@ class ChangeHandler(
 
     fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_REQUIRED_CHANGE_INFORMATION }
 
         runCatching {
             logger.info { "Transitioning change request phase: ${phase.name}" }
@@ -304,7 +304,7 @@ class ChangeHandler(
 
     fun monitor(approvalCheckInterval: Int): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_REQUIRED_CHANGE_INFORMATION }
 
         val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
         logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
@@ -334,28 +334,8 @@ class ChangeHandler(
     }
 
     fun getChange(): Change {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_REQUIRED_CHANGE_INFORMATION }
         return change
-    }
-
-    fun comment(comment: String): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
-        if (comment.isNotEmpty()) {
-            logger.info { "Adding custom comment to change." }
-            changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
-        }
-        return this
-    }
-
-    fun getComments(changeId: String): List<ChangeComment> {
-        return changeManagementRepository.getComments(changeId, auth)
-    }
-
-    fun getUrl(): String {
-        require(::change.isInitialized) { "Missing required change information." }
-        val url = change.self
-        requireNotNull(url)
-        return url
     }
 
     private fun logChangeRequestStatus(changeRequest: Change) {

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -85,10 +85,13 @@ open class SharepointClient(private val user: String, private val password: Stri
         val httpEntity = EntityBuilder.create().apply {
             text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
         }.build()
+        val httpEntity = EntityBuilder.create().apply {
+            text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
+        }.build()
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", CONTENT_TYPE_JSON_ODATA_VERBOSE)
             addHeader("X-RequestDigest", digest)
-            addHeader("Content-Type", "application/json;odata=verbose")
+            addHeader("Content-Type", CONTENT_TYPE_JSON_ODATA_VERBOSE)
             entity = httpEntity
         }
 
@@ -157,7 +160,7 @@ open class SharepointClient(private val user: String, private val password: Stri
     private fun getSharepointApprovalConfigurations(): SharepointApprovalConfigurations {
         val httpGet =
             HttpGet("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approval%20Configuration')/items").apply {
-                addHeader("Accept", "application/json;odata=verbose")
+                addHeader("Accept", CONTENT_TYPE_JSON_ODATA_VERBOSE)
             }
         client.execute(httpGet).use { response ->
             logger.info { "Executed request ${httpGet.requestLine} --- ${response.statusLine}" }
@@ -173,6 +176,10 @@ open class SharepointClient(private val user: String, private val password: Stri
         const val ISHARE_WEBAPPROVAL_BASE_URL = "${ISHARE_BASE_URL}/sites/it-sec"
         const val ISHARE_PROD_LIST = "Pipeline%20Approvals"
         const val ISHARE_TEST_LIST = "Pipeline%20Approvals%20TEST"
+        const val ISHARE_WEBAPPLICATION_BY_ID_URL =
+            "https://itm.prg-dc.dhl.com/sites/it-sec/Lists/Pipeline%20Approval%20Configuration/DispForm.aspx?ID="
+        const val CONTENT_TYPE_JSON_ODATA_VERBOSE = "application/json;odata=verbose"
+    }
         const val ISHARE_WEBAPPLICATION_BY_ID_URL =
             "https://itm.prg-dc.dhl.com/sites/it-sec/Lists/Pipeline%20Approval%20Configuration/DispForm.aspx?ID="
     }

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -22,11 +22,13 @@ data class LicenseBlackListEntry(
 
 object OslcComplianceChecker : KLogging() {
 
+    private const val NOT_FOUND: String = "not found"
+
     private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: NOT_FOUND
     private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: NOT_FOUND
+    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: NOT_FOUND
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -3,17 +3,23 @@ package de.deutschepost.sdm.cdlib.utils
 import java.io.File
 import java.security.MessageDigest
 
+class Utils {
+    companion object {
+        const val HASH_ALGORITHM = "SHA-256"
+    }
+}
+
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Utils.HASH_ALGORITHM)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Utils.HASH_ALGORITHM)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Utils.HASH_ALGORITHM)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -25,7 +25,6 @@ import toArgsArray
 import withStandardOutput
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
 import kotlin.random.Random
 
 @RequiresTag("IntegrationTest")
@@ -79,6 +78,10 @@ class ChangeOslcIntegrationTest(
     }
 
     init {
+        companion object {
+            const val ENTRY_URL_LABEL = "EntryUrl: "
+        }
+
         context("Creating oslc change is a success") {
             test("change create --oslc missing distribution") {
                 val (ret, output) = withStandardOutput {
@@ -96,7 +99,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL_LABEL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
             }
@@ -107,7 +110,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL_LABEL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0
@@ -119,7 +122,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcGradlePluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL_LABEL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -199,108 +199,121 @@ class ChangeCloseIntegrationTest(
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
 
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
+                const val DASHBOARD_STATUS_MESSAGE = "Dashboard status code: 201"
+                
+                "Closing change successfully publishes metrics via Jenkins" {
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "http://integration-test-url.jenkuns.example.com"
+                        output shouldContain DASHBOARD_STATUS_MESSAGE
+                        exitCode shouldBeExactly 0
+                    }
                 }
-
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
-            withEnvironment(
-                "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
-                    )
+                
+                "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "http://integration-test-url.jenkuns.example.com"
+                        output shouldContain DASHBOARD_STATUS_MESSAGE
+                        output shouldContain "INFRA"
+                        exitCode shouldBeExactly 0
+                    }
                 }
-
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                output shouldContain "INFRA"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via AzureDevOps" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
-                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
+                
+                "Closing change successfully publishes metrics via AzureDevOps" {
+                    val rnd = UUID.randomUUID().toString().substringBefore("-")
+                
+                    withEnvironment(
+                        mapOf(
+                            "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
+                            "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
+                        ),
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
+                        output shouldContain DASHBOARD_STATUS_MESSAGE
+                        exitCode shouldBeExactly 0
+                    }
                 }
-
-                output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully when having a fuzzy matching job url" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-            }
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
-                    "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-
-                val (exitCode, output) = withStandardOutput {
-                    changeHandler
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
+                
+                "Closing change successfully when having a fuzzy matching job url" {
+                    val rnd = UUID.randomUUID().toString().substringBefore("-")
+                
+                    withEnvironment(
+                        "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                    }
+                
+                    withEnvironment(
+                        mapOf(
+                            "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
+                            "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
+                        ),
+                        OverrideMode.SetOrOverride
+                    ) {
+                
+                        val (exitCode, output) = withStandardOutput {
+                            changeHandler
+                                .post(changeDetails)
+                                .preauthorize()
+                                .transition(OPEN_TO_IMPLEMENTATION)
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
+                        output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
+                        output shouldContain DASHBOARD_STATUS_MESSAGE
+                        exitCode shouldBeExactly 0
+                    }
                 }
-
-                output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
-                output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
         }
 
         "Change close with custom comment is succesful and adds the comment." {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -142,20 +142,20 @@ class ChangeCloseIntegrationTest(
                 .post(changeDetails)
                 .preauthorize()
                 .transition(OPEN_TO_IMPLEMENTATION)
-
+        
             val (exitCode, output) = withStandardOutput {
                 PicocliRunner.call(
                     ChangeCommand.CloseCommand::class.java,
                     *"--debug --test --jira-token $token --commercial-reference $commercialReference --status SUCCESS".toArgsArray()
                 )
             }
-
+        
             output shouldNotContain "Failed to parse Pipeline status"
             output shouldNotContain "Failed to create metric object."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain Companion.PUSHING_METRIC_OBJECT
             exitCode shouldBe 0
         }
-
+        
         "Change is not closed for failed status" {
             listOf("FAILED", "FAILURE").forAll {
                 val (exitCode, output) = withStandardOutput {
@@ -170,7 +170,17 @@ class ChangeCloseIntegrationTest(
                 }
                 output shouldNotContain "Closing change"
                 output shouldContain "not closing change request."
-                output shouldContain "Pushing following metric object:"
+                output shouldContain Companion.PUSHING_METRIC_OBJECT
+                exitCode shouldBe 0
+        
+                changeHandler.findExisting().closeExisting()
+                Thread.sleep(15.toDuration(DurationUnit.SECONDS).inWholeMilliseconds)
+            }
+        }
+        
+        companion object {
+            const val PUSHING_METRIC_OBJECT = "Pushing following metric object:"
+        }
                 exitCode shouldBe 0
 
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -52,6 +52,10 @@ class ChangeCreateCommandTest(
             output shouldContain "Invalid value for option '--category': expected one of [ROLLOUT, NO_ROLLOUT, AUTHORIZATIONS, DATA_MAINTENANCE, TECHNICAL_REQUIREMENTS, LEGAL_OR_CONTRACTUAL_REQUIREMENTS, HOUSEKEEPING, CAPACITY_ADJUSTMENTS, SECURITY, TROUBLESHOOTING, OTHER] (case-sensitive) but was 'jellyfish'"
         }
 
+        companion object {
+            const val ILLEGAL_ARGUMENT_EXCEPTION = "java.lang.IllegalArgumentException"
+        }
+
         "Create change request fails due to missing commercial reference" {
             val (_, output) = withErrorOutput {
                 PicocliRunner.call(
@@ -71,7 +75,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
         }
 
         "Command fails if oslc but no distribution was passed" {
@@ -82,7 +86,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
         }
 
         "Command doesn't fail if no-oslc and no distribution was passed" {
@@ -93,8 +97,9 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
             output shouldContain "Verifying reports..."
+        }
         }
 
         "Parsing deployment status string returns expected enum" {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
@@ -7,7 +7,6 @@ import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.App
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.Category.HOUSEKEEPING
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangePhaseId.OPEN_TO_IMPLEMENTATION
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangeStatus.AWAITING_IMPLEMENTATION
-import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangeStatus.WAITING_FOR_APPROVAL
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangeType.MAJOR
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.Criticality.OPERATIONAL
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.FieldDefaults.APPROVAL_CHECK_TIMEOUT_IN_MINUTES
@@ -83,23 +82,7 @@ class ChangeCreateIntegrationTest(
                         *"change create --test --skip-approval-wait --jira-token $token --no-oslc --no-webapproval --no-tqs --commercial-reference $commercialReference".toArgsArray()
                     )
                 }
-                output shouldContain "CDLib version 0.2.0-INTEGRATION-TEST is not supported anymore. Please update to a newer version. Pre-authorization is not possible."
-                output shouldContain "A new version of CDLib is available"
-
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Could not find changes to close nor resume for the current pipeline"
-                output shouldContain "Posting change request"
-                output shouldContain "Determining whether change can be preauthorized."
-                output shouldContain "  CDLib version is supported: false\n" +
-                    "  Impact Class: ${NONE.name}\n" +
-                    "  Business Criticality: ${OPERATIONAL.name}\n" +
-                    "  Determined change type --> MINOR"
-                output shouldContain "Updating change request type: MINOR"
-                output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
-
+                const val CHECK_STATUS_MESSAGE = "Checking change request status for approval every"
             }
             changeTestHelper.closeChangeRequest(
                 token,

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -161,6 +161,11 @@ class ChangeManagementRepositoryTest(
             val businessYearAttributeId = 3
             val almId = "almId"
             val businessYear = "2022"
+            val companion object {
+                const val BUSINESS_CRITICALITY = "Business Kritikalität"
+            }
+            
+            val businessYear = "2022"
             val businessYearLater = "2023"
             val itSystemName = "itSystemName"
             val itSystemKey = "itSystemKey"
@@ -184,7 +189,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_CRITICALITY,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -195,6 +200,27 @@ class ChangeManagementRepositoryTest(
                                                     objectTypeAttributeId = itSystemAttributeId
                                                 )
                                             ),
+                                            objectType = JiraObjectType(
+                                                name = BUSINESS_CRITICALITY,
+                                                6
+                                            ),
+                                            objectKey = "objectKey",
+                                            label = "label"
+                                        ),
+                                    )
+                                ),
+                                objectTypeAttributeId = itSystemAttributeId
+                            ),
+                            JiraAttribute(
+                                objectAttributeValues = listOf(
+                                    JiraObjectAttributeValue(
+                                        displayValue = almId,
+                                        searchValue = almId,
+                                        referencedObject = null,
+                                    )
+                                ),
+                                objectTypeAttributeId = almAttributeId
+                            ),
                                             objectType = JiraObjectType(
                                                 name = "Business Kritikalität",
                                                 6

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
@@ -29,6 +29,10 @@ class NameResolverAzureTest(
     private val resolver: NameResolverAzure,
     private val namesConfigWithDefault: NamesConfigWithDefault
 ) : AnnotationSpec() {
+    companion object {
+        private const val BUILD_DEFINITION_NAME = "ICTO-3339_SDM-phippyandfriends"
+    }
+) : AnnotationSpec() {
     private val before = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toInstant()
 
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -4,7 +4,6 @@ import de.deutschepost.sdm.cdlib.CdlibCommand
 import de.deutschepost.sdm.cdlib.names.git.GitRepository
 import de.deutschepost.sdm.cdlib.names.git.GitRevision
 import io.kotest.core.annotation.RequiresTag
-import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.extensions.system.OverrideMode
 import io.kotest.extensions.system.SystemEnvironmentTestListener
@@ -55,75 +54,83 @@ class NamesCommandAzureTest : AnnotationSpec() {
     }
 
     @Test
-    fun testNamesCreate() {
-        val (_, output) = withStandardOutput {
-            val args = "names create".toArgsArray()
-            PicocliRunner.run(CdlibCommand::class.java, *args)
+    class TestClass {
+        companion object {
+            private const val CDLIB_APP_NAME_VARIABLE = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
         }
-
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_REVISION;isOutput=true]a5c5bc3"
-    }
-
-    @Test
-    fun testNamesCreateOverrideOrigin() {
-        val origin = "https://git.dhl.com/Overriden/Origin.git"
-        val (_, output) = withStandardOutput {
-            val args = "names create --override-origin $origin".toArgsArray()
-            PicocliRunner.run(CdlibCommand::class.java, *args)
-        }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ORIGIN;isOutput=true]$origin"
-    }
-
-    @Test
-    fun testNamesCreateWithValidReleaseName() {
-        val (_, output) = withStandardOutput {
-            val releaseName = "ICTO-3339_SDM-phippyandfriends_20211203.1809.18_20210908.16_a5c5bc3"
-            val args = "names create --from-release-name $releaseName".toArgsArray()
-            PicocliRunner.run(CdlibCommand::class.java, *args)
-        }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_VERSION;isOutput=true]20211203.1809.18"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_BUILD_NUMBER;isOutput=true]20210908.16"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_VERSION;isOutput=true]20211203.1809.18_20210908.16_a5c5bc3"
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_REVISION;isOutput=true]a5c5bc3"
-    }
-
-    @Test
-    fun testNamesCreateWithInvalidReleaseName() {
-        val releaseName = "ICTO-20211203.1809.18_12657_a5c5bc3"
-        val args = "--from-release-name $releaseName".toArgsArray()
-
-        val returnCode = PicocliRunner.call(NamesCommand.CreateCommand::class.java, *args)
-        returnCode shouldBeEqualComparingTo -1
-    }
-
-    @Test
-    fun testPREffectiveBranchName() {
-        withEnvironment(
-            mapOf(
-                "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "refs/heads/i593_test",
-                "BUILD_SOURCEBRANCHNAME" to "merge",
-            ),
-            OverrideMode.SetOrOverride
-        ) {
+    
+        @Test
+        fun testNamesCreate() {
             val (_, output) = withStandardOutput {
                 val args = "names create".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-
-            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+    
+            output shouldContainIgnoringCase CDLIB_APP_NAME_VARIABLE
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_REVISION;isOutput=true]a5c5bc3"
         }
+    
+        @Test
+        fun testNamesCreateOverrideOrigin() {
+            val origin = "https://git.dhl.com/Overriden/Origin.git"
+            val (_, output) = withStandardOutput {
+                val args = "names create --override-origin $origin".toArgsArray()
+                PicocliRunner.run(CdlibCommand::class.java, *args)
+            }
+            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ORIGIN;isOutput=true]$origin"
+        }
+    
+        @Test
+        fun testNamesCreateWithValidReleaseName() {
+            val (_, output) = withStandardOutput {
+                val releaseName = "ICTO-3339_SDM-phippyandfriends_20211203.1809.18_20210908.16_a5c5bc3"
+                val args = "names create --from-release-name $releaseName".toArgsArray()
+                PicocliRunner.run(CdlibCommand::class.java, *args)
+            }
+            output shouldContainIgnoringCase CDLIB_APP_NAME_VARIABLE
+            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_VERSION;isOutput=true]20211203.1809.18"
+            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_BUILD_NUMBER;isOutput=true]20210908.16"
+            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
+            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
+            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
+            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_VERSION;isOutput=true]20211203.1809.18_20210908.16_a5c5bc3"
+            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_REVISION;isOutput=true]a5c5bc3"
+        }
+    
+        @Test
+        fun testNamesCreateWithInvalidReleaseName() {
+            val releaseName = "ICTO-20211203.1809.18_12657_a5c5bc3"
+            val args = "--from-release-name $releaseName".toArgsArray()
+    
+            val returnCode = PicocliRunner.call(NamesCommand.CreateCommand::class.java, *args)
+            returnCode shouldBeEqualComparingTo -1
+        }
+    
+        @Test
+        fun testPREffectiveBranchName() {
+            withEnvironment(
+                mapOf(
+                    "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "refs/heads/i593_test",
+                    "BUILD_SOURCEBRANCHNAME" to "merge",
+                ),
+                OverrideMode.SetOrOverride
+            ) {
+                val (_, output) = withStandardOutput {
+                    val args = "names create".toArgsArray()
+                    PicocliRunner.run(CdlibCommand::class.java, *args)
+                }
+    
+                output shouldContainIgnoringCase CDLIB_APP_NAME_VARIABLE
+                output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
+                output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
+                output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
+                output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_REVISION;isOutput=true]a5c5bc3"
+            }
+        }
+    }
 
     }
 }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -10,15 +10,20 @@ import toArgsArray
 import withStandardOutput
 
 @RequiresTag("UnitTest")
+@RequiresTag("UnitTest")
 @Tags("UnitTest")
 class NamesCommandTest : DescribeSpec({
+    companion object {
+        const val SHOULD_DISPLAY_HELP = "should display help"
+    }
+
     describe("cdlib names") {
         describe("names -h") {
             val (_, output) = withStandardOutput {
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(SHOULD_DISPLAY_HELP) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }
@@ -29,7 +34,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(SHOULD_DISPLAY_HELP) {
                 output shouldContain "Create canonical set of standard names and IDs"
                 output shouldContain "Name of optional output file"
                 output shouldContain "Release name to use for derived name creation"
@@ -43,8 +48,11 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(SHOULD_DISPLAY_HELP) {
                 output shouldContain "Dumps the list of environment variables"
+                output shouldContain "Name of optional output file"
+            }
+        }
                 output shouldContain "Name of optional output file"
             }
         }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -1,5 +1,6 @@
 package de.deutschepost.sdm.cdlib.names.git
 
+import io.kotest.core.annotation.BeforeAll
 import io.kotest.core.annotation.RequiresTag
 import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.AnnotationSpec
@@ -21,23 +22,26 @@ class RepositoryTest : AnnotationSpec() {
             id = "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
-            authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
-            committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
-        )
-    }
-
-    @Test
-    fun testLastCommit() {
-        val revision = GitRepository.lastBranchCommit(currDir)
-        revision.id shouldBeEqualComparingTo "a5c5bc3ce1907e844490697b9aa22c4196c5d781"
-        revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
-        revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
-        revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
-        revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+            class RepositoryTest : AnnotationSpec() {
+                companion object {
+                    const val AUTHOR_EMAIL = "f.l@dhl.com"
+                }
+                private val currDir = System.getProperty("user.dir")
+            
+                @BeforeAll
+                fun initMocks() {
+                    mockkObject(GitRepository)
+                    every { GitRepository.getRemoteUrl(any()) } returns "https://git.dhl.com/CDLib/CDlib.git"
+                    every { GitRepository.lastBranchCommit(any()) } returns GitRevision(
+                        id = "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
+                        longMessage = "Dummy Commit",
+                        shortMessage = "Dummy Commit",
+                        authorName = "Firstname Lastname",
+                        authorEmail = AUTHOR_EMAIL,
+                        committerName = "Firstname Lastname",
+                        committerEmail = AUTHOR_EMAIL
+                    )
+                }
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -3,7 +3,6 @@ package de.deutschepost.sdm.cdlib.release
 import de.deutschepost.sdm.cdlib.release.report.TestResultPrefixes
 import getSystemEnvironmentTestListenerWithOverrides
 import io.kotest.core.annotation.RequiresTag
-import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.string.shouldContain
@@ -68,43 +67,52 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
-                output shouldNotContain "Unapproved Licenses Count: 0"
-            }
-
-            test("Check OSLC-Plugin report locally should succeed with accepted list") {
-                val args =
-                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFile".toArgsArray()
-                val (ret, output) = withStandardOutput {
-                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                const val POLICY_PROFILE_DISTRIBUTION = "Policy Profile: Distribution"
+                
+                test("Check OSLC-Plugin report locally should fail due to distribution flag") {
+                    val args = "--debug --files $jsonFile --distribution".toArgsArray()
+                    val (ret, output) = withStandardOutput {
+                        PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                    }
+                    ret shouldBeExactly -1
+                    output shouldContain POLICY_PROFILE_DISTRIBUTION
+                    output shouldNotContain "Unapproved Licenses Count: 0"
                 }
-                ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
-                output shouldContain "Unapproved Licenses Count: 0"
-            }
-
-            test("Check OSLC-Plugin report locally should fail with accepted list because of wrong license") {
-                val args =
-                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongLicense".toArgsArray()
-                val (ret, output) = withStandardOutput {
-                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                
+                test("Check OSLC-Plugin report locally should succeed with accepted list") {
+                    val args =
+                        "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFile".toArgsArray()
+                    val (ret, output) = withStandardOutput {
+                        PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                    }
+                    ret shouldBeExactly 0
+                    output shouldContain POLICY_PROFILE_DISTRIBUTION
+                    output shouldContain "Unapproved Licenses Count: 0"
                 }
-                ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
-                output shouldContain "Unapproved Licenses Count: 1"
-                output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
-            }
-
-            test("Check OSLC-Plugin report locally should fail with accepted list because of wrong version number") {
-                val args =
-                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongVersion".toArgsArray()
-                val (ret, output) = withStandardOutput {
-                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                
+                test("Check OSLC-Plugin report locally should fail with accepted list because of wrong license") {
+                    val args =
+                        "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongLicense".toArgsArray()
+                    val (ret, output) = withStandardOutput {
+                        PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                    }
+                    ret shouldBeExactly -1
+                    output shouldContain POLICY_PROFILE_DISTRIBUTION
+                    output shouldContain "Unapproved Licenses Count: 1"
+                    output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
                 }
-                ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
-                output shouldContain "Unapproved Licenses Count: 1"
-                output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
+                
+                test("Check OSLC-Plugin report locally should fail with accepted list because of wrong version number") {
+                    val args =
+                        "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongVersion".toArgsArray()
+                    val (ret, output) = withStandardOutput {
+                        PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                    }
+                    ret shouldBeExactly -1
+                    output shouldContain POLICY_PROFILE_DISTRIBUTION
+                    output shouldContain "Unapproved Licenses Count: 1"
+                    output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
+                }
             }
 
             test("Trying to upload failing OSLC-Plugin report to artifactory should missing") {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -40,6 +40,10 @@ class ReportOslcNPMPluginIntegrationTest(
         )
     )
 
+    companion object {
+        private const val UPLOADED_ARTIFACT_MESSAGE = "Uploaded Artifact:"
+    }
+    
     init {
         context("Check OSLC-Plugin report and upload") {
             test("Check OSLC-Plugin report locally") {
@@ -50,7 +54,7 @@ class ReportOslcNPMPluginIntegrationTest(
                 ret shouldBeExactly 0
                 output shouldContain "Policy Profile: Non-Distribution"
             }
-
+    
             test("Upload OSLC-Plugin report to artifactory") {
                 val args =
                     "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
@@ -58,9 +62,9 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT_MESSAGE
             }
-            // TODO: Delete after sundown
+    
             test("Upload OSLC-Plugin report to LCM artifactory") {
                 val args =
                     "--debug --files $jsonFile --no-distribution --artifactory-azure-instance --artifactory-identity-token $artifactoryLCMIdentityToken --repo-name $repoLCMName --type build".toArgsArray()
@@ -68,9 +72,9 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT_MESSAGE
             }
-
+    
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
                 val args = "--debug --files $jsonFailingFile --distribution".toArgsArray()
                 val (ret, output) = withStandardOutput {
@@ -79,16 +83,16 @@ class ReportOslcNPMPluginIntegrationTest(
                 ret shouldBeExactly -1
                 output shouldContain "Policy Profile: Distribution"
             }
-
+    
             test("Trying to upload failing OSLC-Plugin report to artifactory should missing") {
-
+    
                 val args =
                     "--debug --files $jsonFailingFile --distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
                 val (ret, output) = withStandardOutput {
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldNotContain "Uploaded Artifact:"
+                output shouldNotContain UPLOADED_ARTIFACT_MESSAGE
             }
         }
     }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -14,7 +14,6 @@ import io.kotest.core.annotation.RequiresTag
 import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldNotBeEmpty
-import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.maps.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
@@ -23,45 +22,27 @@ import java.io.File
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class FnciReportTest : FunSpec({
-    val projectPath = "src/test/resources/fnci/fnci-project.json"
-    val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
-    context("Project Info") {
-        test("Parses projectInfo correctly") {
-            val projectInfo = permissiveObjectMapper.readValue(
-                File(projectPath), FnciProjectInfoWrapper::class.java
-            ).data
-            projectInfo.policyProfileName shouldBe "Non-Distribution insecure"
-            defaultObjectMapper.writeValue(System.out, projectInfo)
+    class FnciReportTest : FunSpec({
+        companion object {
+            private const val PROJECT_PATH = "src/test/resources/fnci/fnci-project.json"
         }
-    }
-
-    context("Inventory") {
-        test("Parse inventory correctly") {
-            val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(
-                File(inventoryPath)
-            )
-            val inventoryParts = inventory.partition { it.inventoryReviewStatus == "Approved" }
-            inventoryParts.first.shouldNotBeEmpty()
-            inventoryParts.second.shouldNotBeEmpty()
+    
+        val projectPath = PROJECT_PATH
+        val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
+        context("Project Info") {
+            test("Parses projectInfo correctly") {
+                val projectInfo = permissiveObjectMapper.readValue(
+                    File(projectPath), FnciProjectInfoWrapper::class.java
+                ).data
+                projectInfo.policyProfileName shouldBe "Non-Distribution insecure"
+                defaultObjectMapper.writeValue(System.out, projectInfo)
+            }
         }
-    }
-
-    context("OslcTestResult") {
-        val projectInfo: FnciProjectInfo =
-            permissiveObjectMapper.readValue(File(projectPath), FnciProjectInfoWrapper::class.java).data
-        val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
-        test("Generate OslcTestResult") {
-            val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
-            report.complianceStatus shouldBe OslcComplianceStatus.RED
-            report.unapprovedItems.shouldNotBeEmpty()
-            defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
-        }
-
-        test("Only approved is compliant") {
-            val report = OslcTestResult.from(
-                FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+    
+        context("OslcTestResult") {
+            val projectInfo: FnciProjectInfo =
+                permissiveObjectMapper.readValue(File(PROJECT_PATH), FnciProjectInfoWrapper::class.java).data
+            val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -1,12 +1,7 @@
 package de.deutschepost.sdm.cdlib.release.report
 
-import de.deutschepost.sdm.cdlib.release.report.external.OslcGradlePluginTestResult
-import de.deutschepost.sdm.cdlib.release.report.external.from
-import de.deutschepost.sdm.cdlib.release.report.internal.OslcTestResult
 import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcComplianceChecker
-import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcTestPreResult
 import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.VersionSpecification
-import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.from
 import de.deutschepost.sdm.cdlib.utils.permissiveObjectMapper
 import getSystemEnvironmentTestListenerWithOverrides
 import io.kotest.assertions.throwables.shouldThrow
@@ -16,7 +11,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.headers
 import io.kotest.data.row
 import io.kotest.data.table
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import withStandardOutput
@@ -46,89 +40,120 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
-                        row("0.0.0", 0, VersionSpecification(0, 0, 0)),
-                        row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
-                        row("1.2.3", 0, VersionSpecification(1, 2, 3)),
-                        row("1.2.3.4", 0, VersionSpecification(1, 2, 3)),
-                        row("1", 0, VersionSpecification(1, 0, 0)),
-                        row("6.6", 6, VersionSpecification(6, 6, 6)),
-                    )
-                ) { input: String, default: Int, expected: VersionSpecification ->
-                    VersionSpecification.fromString(input, default) shouldBe expected
-                }
-            }
-
-            test("Testing invalid input strings") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Input String", "Default Value"),
-                        row("a.b.c", 0),
-                        row("error", 0),
-                        row("3,2,5", 0),
-                    )
-                ) { input: String, default: Int ->
-                    shouldThrow<NumberFormatException> { VersionSpecification.fromString(input, default) }
-                }
-            }
-
-            test("Testing valid ranged input strings") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
-                        row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
-                        row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
-                        row(
-                            "1.2.3-",
-                            VersionSpecification(1, 2, 3),
-                            VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
-                        ),
-                        row("1-1.5", VersionSpecification(1, 0, 0), VersionSpecification(1, 5, Int.MAX_VALUE)),
-                        row(
-                            "-",
-                            VersionSpecification(0, 0, 0),
-                            VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
-                        ),
-                        row(
-                            "",
-                            VersionSpecification(0, 0, 0),
-                            VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
-                        ),
-                        row("11.12.13", VersionSpecification(11, 12, 13), VersionSpecification(11, 12, 13)),
-                    )
-                ) { input: String, min: VersionSpecification, max: VersionSpecification ->
-                    VersionSpecification.rangeFromString(input) shouldBe min..max
-                }
-            }
-
-            test("Testing invalid ranged input strings") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Input String"),
-                        row("1.2.3-11.12.13-1.2.3"),
-                        row("1-1-1"),
-                    )
-                ) { input: String ->
-                    shouldThrow<RuntimeException> { VersionSpecification.rangeFromString(input) }
-                }
-            }
-
-            test("Testing isInBetween") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Min", "Input", "Max", "Expected"),
-                        row(
-                            VersionSpecification(1, 2, 3),
-                            VersionSpecification(1, 3, 3),
-                            VersionSpecification(2, 1, 1),
-                            true
-                        ),
-                        row(
-                            VersionSpecification(1, 2, 3),
-                            VersionSpecification(1, 1, 3),
-                            VersionSpecification(2, 1, 1),
-                            false
-                        ),
+                        companion object {
+                            const val INPUT_STRING = "Input String"
+                        }
+                        
+                        test("Testing valid input strings") {
+                            io.kotest.data.forAll(
+                                table(
+                                    headers(INPUT_STRING, "Default Value", "Expected"),
+                                    row("0.0.0", 0, VersionSpecification(0, 0, 0)),
+                                    row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
+                                    row("1.2.3", 0, VersionSpecification(1, 2, 3)),
+                                    row("1.2.3.4", 0, VersionSpecification(1, 2, 3)),
+                                    row("1", 0, VersionSpecification(1, 0, 0)),
+                                    row("6.6", 6, VersionSpecification(6, 6, 6)),
+                                )
+                            ) { input: String, default: Int, expected: VersionSpecification ->
+                                VersionSpecification.fromString(input, default) shouldBe expected
+                            }
+                        }
+                        
+                        test("Testing invalid input strings") {
+                            io.kotest.data.forAll(
+                                table(
+                                    headers(INPUT_STRING, "Default Value"),
+                                    row("a.b.c", 0),
+                                    row("error", 0),
+                                    row("3,2,5", 0),
+                                )
+                            ) { input: String, default: Int ->
+                                shouldThrow<NumberFormatException> { VersionSpecification.fromString(input, default) }
+                            }
+                        }
+                        
+                        test("Testing valid ranged input strings") {
+                            io.kotest.data.forAll(
+                                table(
+                                    headers(INPUT_STRING, "ExpectedMin", "ExpectedMax"),
+                                    row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
+                                    row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
+                                    row(
+                                        "1.2.3-",
+                                        VersionSpecification(1, 2, 3),
+                                        VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
+                                    ),
+                                    row("1-1.5", VersionSpecification(1, 0, 0), VersionSpecification(1, 5, Int.MAX_VALUE)),
+                                    row(
+                                        "-",
+                                        VersionSpecification(0, 0, 0),
+                                        VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
+                                    ),
+                                    row(
+                                        "",
+                                        VersionSpecification(0, 0, 0),
+                                        VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
+                                    ),
+                                    row("11.12.13", VersionSpecification(11, 12, 13), VersionSpecification(11, 12, 13)),
+                                )
+                            ) { input: String, min: VersionSpecification, max: VersionSpecification ->
+                                VersionSpecification.rangeFromString(input) shouldBe min..max
+                            }
+                        }
+                        
+                        test("Testing invalid ranged input strings") {
+                            io.kotest.data.forAll(
+                                table(
+                                    headers(INPUT_STRING),
+                                    row("1.2.3-11.12.13-1.2.3"),
+                                    row("1-1-1"),
+                                )
+                            ) { input: String ->
+                                shouldThrow<RuntimeException> { VersionSpecification.rangeFromString(input) }
+                            }
+                        }
+                        
+                        test("Testing isInBetween") {
+                            io.kotest.data.forAll(
+                                table(
+                                    headers("Min", INPUT_STRING, "Max", "Expected"),
+                                    row(
+                                        VersionSpecification(1, 2, 3),
+                                        VersionSpecification(1, 3, 3),
+                                        VersionSpecification(2, 1, 1),
+                                        true
+                                    ),
+                                    row(
+                                        VersionSpecification(1, 2, 3),
+                                        VersionSpecification(1, 1, 3),
+                                        VersionSpecification(2, 1, 1),
+                                        false
+                                    ),
+                                    row(
+                                        VersionSpecification(1, 2, 3),
+                                        VersionSpecification(1, 2, 3),
+                                        VersionSpecification(1, 2, 3),
+                                        true
+                                    ),
+                                    row(
+                                        VersionSpecification(1, 0, 0),
+                                        VersionSpecification(3, 0, 0),
+                                        VersionSpecification(2, 0, 0),
+                                        false
+                                    ),
+                                    row(
+                                        VersionSpecification(1, 0, 0),
+                                        VersionSpecification(2, 0, 1),
+                                        VersionSpecification(2, 1, 0),
+                                        true
+                                    ),
+                        
+                                    )
+                            ) { min: VersionSpecification, input: VersionSpecification, max: VersionSpecification, expected: Boolean ->
+                                (input in min..max) shouldBe expected
+                            }
+                        }
                         row(
                             VersionSpecification(1, 2, 3),
                             VersionSpecification(1, 2, 3),


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
