### PR TITLE
Sonar: Do not hardcode version numbers. (rule kotlin:S6624)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,4 @@
+implementation("org.apache.httpcomponents:httpclient:$httpComponentsVersion")
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -55,7 +56,7 @@ dependencies {
     implementation("org.jfrog.artifactory.client:artifactory-java-client-services:$artifactoryClientVersion")
     // logging
     implementation("io.github.microutils:kotlin-logging:2.1.23")
-    // webapproval sharepoint
+    implementation("org.apache.httpcomponents:httpclient:$httpComponentsVersion")
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
     implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -30,6 +30,10 @@ micronaut {
 val kotlinVersion = project.properties["kotlinVersion"] as String
 val kotlinCoroutines = project.properties["kotlinCoroutines"] as String
 
+val kotlinVersion = project.properties["kotlinVersion"] as String
+val kotlinCoroutines = project.properties["kotlinCoroutines"] as String
+val jsonSmartVersion = "2.5.2"
+
 dependencies {
     ksp("info.picocli:picocli-codegen")
     implementation("org.yaml:snakeyaml")
@@ -51,11 +55,11 @@ dependencies {
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
     //publish metrics to azure cosmosdb
     implementation("com.azure:azure-identity")
-    implementation("net.minidev:json-smart:2.5.2") // override bc vuln
+    implementation("net.minidev:json-smart:$jsonSmartVersion") // override bc vuln
     implementation("com.azure:azure-cosmos")
     //publish metrics to azure cosmosdb
     implementation("com.azure:azure-identity")
-    implementation("net.minidev:json-smart:2.5.2") // override bc vuln
+    implementation("net.minidev:json-smart:$jsonSmartVersion") // override bc vuln
     implementation("com.azure:azure-cosmos")
 
     // Tests only

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -35,10 +35,15 @@ dependencies {
     implementation("io.micronaut.picocli:micronaut-picocli")
     implementation("io.micronaut:micronaut-retry")
     implementation("javax.annotation:javax.annotation-api") // todo remove?
-    implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${kotlinCoroutines}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${kotlinCoroutines}")
+    val kotlinReflectVersion = kotlinVersion
+    val kotlinStdlibJdk8Version = kotlinVersion
+    val kotlinCoroutinesCoreVersion = kotlinCoroutines
+    val kotlinCoroutinesReactiveVersion = kotlinCoroutines
+    
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinReflectVersion")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinStdlibJdk8Version")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesCoreVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$kotlinCoroutinesReactiveVersion")
     implementation("ch.qos.logback:logback-classic")
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,4 @@
+implementation("org.apache.httpcomponents:httpclient:$httpClientVersion")
 implementation("org.apache.httpcomponents:httpclient:$httpComponentsVersion")
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -35,11 +36,12 @@ dependencies {
     implementation("io.micronaut.kotlin:micronaut-kotlin-runtime")
     implementation("io.micronaut.picocli:micronaut-picocli")
     implementation("io.micronaut:micronaut-retry")
-    implementation("javax.annotation:javax.annotation-api") // todo remove?
     val kotlinReflectVersion = kotlinVersion
     val kotlinStdlibJdk8Version = kotlinVersion
     val kotlinCoroutinesCoreVersion = kotlinCoroutines
     val kotlinCoroutinesReactiveVersion = kotlinCoroutines
+    
+    val httpClientVersion = "4.5.14"
     
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinReflectVersion")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinStdlibJdk8Version")
@@ -47,11 +49,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$kotlinCoroutinesReactiveVersion")
     implementation("ch.qos.logback:logback-classic")
     implementation("io.micronaut:micronaut-jackson-databind")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
-
-    val artifactoryClientVersion = "2.19.1"
     
     implementation("org.jfrog.artifactory.client:artifactory-java-client-services:$artifactoryClientVersion")
     // logging

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,5 +1,7 @@
+implementation("com.azure:azure-cosmos")
+implementation("net.minidev:json-smart:2.5.2")
+implementation("com.azure:azure-identity")
 implementation("org.apache.httpcomponents:httpclient:$httpClientVersion")
-implementation("org.apache.httpcomponents:httpclient:$httpComponentsVersion")
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -43,21 +45,14 @@ dependencies {
     
     val httpClientVersion = "4.5.14"
     
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinReflectVersion")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinStdlibJdk8Version")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesCoreVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$kotlinCoroutinesReactiveVersion")
-    implementation("ch.qos.logback:logback-classic")
-    implementation("io.micronaut:micronaut-jackson-databind")
-    
-    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:$artifactoryClientVersion")
-    // logging
-    implementation("io.github.microutils:kotlin-logging:2.1.23")
-    implementation("org.apache.httpcomponents:httpclient:$httpComponentsVersion")
-    implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    implementation("org.apache.httpcomponents:httpclient:$httpClientVersion")
     implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
+    //publish metrics to azure cosmosdb
+    implementation("com.azure:azure-identity")
+    implementation("net.minidev:json-smart:2.5.2") // override bc vuln
+    implementation("com.azure:azure-cosmos")
     //publish metrics to azure cosmosdb
     implementation("com.azure:azure-identity")
     implementation("net.minidev:json-smart:2.5.2") // override bc vuln

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -45,8 +45,9 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
-    // artifactory
-    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:2.19.1")
+    val artifactoryClientVersion = "2.19.1"
+    
+    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:$artifactoryClientVersion")
     // logging
     implementation("io.github.microutils:kotlin-logging:2.1.23")
     // webapproval sharepoint


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>There are several ways to fix it:</p>
<ul>
  <li> extract the versions in variables </li>
  <li> use Spring dependency management plugin: <code>io.spring.dependency-management</code> </li>
  <li> use centralized dependencies with <a
  href="https://www.youtube.com/watch?v=WvtcCCCLfOc&amp;list=PL0UJI1nZ56yAHv9H9kZA6vat4N1kSRGis&amp;index=21">Version Catalogs</a> </li>
</ul>

<h4>Noncompliant code example</h4>
<pre data-diff-id="1" data-diff-type="noncompliant">
dependencies {
    testImplementation("org.mockito:mockito-core:4.5.1")
    testImplementation("org.mockito:mockito-inline:4.5.1")
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
const val mockitoVersion = "4.5.1"

dependencies {
    testImplementation("org.mockito:mockito-core:$mockitoVersion")
    testImplementation("org.mockito:mockito-inline:$mockitoVersion")
}
</pre>
<p>Alternatively, you can put <code>const val mockitoVersion = "4.5.1"</code> in any <code>.kt</code> file in <code>buildSrc/src/main/kotlin</code> or
use a more robust dependency management mechanism like <a href="https://plugins.gradle.org/plugin/io.spring.dependency-management">Spring dependency
management plugin</a> or <a href="https://www.youtube.com/watch?v=WvtcCCCLfOc&amp;list=PL0UJI1nZ56yAHv9H9kZA6vat4N1kSRGis&amp;index=21">Version
Catalogs</a>.</p>
<p>In general hard-coded values is a well known bad practice that affects maintainability. In dependency management, this issue is even more critical
because there is the risk of accidentally having different versions for the same dependency in your configuration.</p>
<p>Keeping hard-coded dependency versions increases the cost of maintainability and complicates the update process.</p>

### These files were changed in the pull request:
#### build.gradle.kts
