### PR TITLE
Sonar: Do not hardcode version numbers. (rule kotlin:S6624)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -57,7 +57,8 @@ dependencies {
     implementation("org.apache.httpcomponents:httpclient:$apacheHttpClientVersion")
     implementation("org.codelibs:jcifs:$jcifsVersion") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
-    implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
+    val jgitVersion = "7.1.0.202411261347-r"
+    implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
     //publish metrics to azure cosmosdb
     implementation("com.azure:azure-identity")
     implementation("net.minidev:json-smart:2.5.2") // override bc vuln

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.kotlin.dsl.val
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -46,7 +47,8 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     // artifactory
-    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:2.19.1")
+    val artifactoryClientVersion = "2.19.1"
+    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryClientVersion}")
     // logging
     implementation("io.github.microutils:kotlin-logging:2.1.23")
     // webapproval sharepoint

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -52,10 +52,10 @@ dependencies {
     val kotlinLoggingVersion = "2.1.23"
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     // webapproval sharepoint
-    // Declare a constant variable for the Apache HttpClient version at the top of the configuration file
     val apacheHttpClientVersion = "4.5.14"
+    val jcifsVersion = "1.3.18.3"
     implementation("org.apache.httpcomponents:httpclient:$apacheHttpClientVersion")
-    implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
+    implementation("org.codelibs:jcifs:$jcifsVersion") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
     //publish metrics to azure cosmosdb

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -52,7 +52,9 @@ dependencies {
     val kotlinLoggingVersion = "2.1.23"
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     // webapproval sharepoint
-    implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    // Declare a constant variable for the Apache HttpClient version at the top of the configuration file
+    val apacheHttpClientVersion = "4.5.14"
+    implementation("org.apache.httpcomponents:httpclient:$apacheHttpClientVersion")
     implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -49,8 +49,8 @@ dependencies {
     // artifactory
     val artifactoryClientVersion = "2.19.1"
     implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryClientVersion}")
-    // logging
-    implementation("io.github.microutils:kotlin-logging:2.1.23")
+    val kotlinLoggingVersion = "2.1.23"
+    implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     // webapproval sharepoint
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
     implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -47,22 +47,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     // artifactory
-    val artifactoryClientVersion = "2.19.1"
-    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryClientVersion}")
-    val kotlinLoggingVersion = "2.1.23"
-    implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
-    // webapproval sharepoint
-    val apacheHttpClientVersion = "4.5.14"
-    val jcifsVersion = "1.3.18.3"
-    implementation("org.apache.httpcomponents:httpclient:$apacheHttpClientVersion")
-    implementation("org.codelibs:jcifs:$jcifsVersion") // Never update this, Version 2 is incompatible
-    // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
-    val jgitVersion = "7.1.0.202411261347-r"
-    implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
-    //publish metrics to azure cosmosdb
-    implementation("com.azure:azure-identity")
-    implementation("net.minidev:json-smart:2.5.2") // override bc vuln
-    implementation("com.azure:azure-cosmos")
+    val jsonSmartVersion = "2.5.2"\n\n// artifactory\nval artifactoryClientVersion = "2.19.1"\nimplementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryClientVersion}")\nval kotlinLoggingVersion = "2.1.23"\nimplementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")\n// webapproval sharepoint\nval apacheHttpClientVersion = "4.5.14"\nval jcifsVersion = "1.3.18.3"\nimplementation("org.apache.httpcomponents:httpclient:$apacheHttpClientVersion")\nimplementation("org.codelibs:jcifs:$jcifsVersion") // Never update this, Version 2 is incompatible\n// JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)\nval jgitVersion = "7.1.0.202411261347-r"\nimplementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")\n//publish metrics to azure cosmosdb\nimplementation("com.azure:azure-identity")\nimplementation("net.minidev:json-smart:${jsonSmartVersion}") // override bc vuln\nimplementation("com.azure:azure-cosmos")
 
     // Tests only
     testImplementation("io.mockk:mockk")


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>There are several ways to fix it:</p>
<ul>
  <li> extract the versions in variables </li>
  <li> use Spring dependency management plugin: <code>io.spring.dependency-management</code> </li>
  <li> use centralized dependencies with <a
  href="https://www.youtube.com/watch?v=WvtcCCCLfOc&amp;list=PL0UJI1nZ56yAHv9H9kZA6vat4N1kSRGis&amp;index=21">Version Catalogs</a> </li>
</ul>

<h4>Noncompliant code example</h4>
<pre data-diff-id="1" data-diff-type="noncompliant">
dependencies {
    testImplementation("org.mockito:mockito-core:4.5.1")
    testImplementation("org.mockito:mockito-inline:4.5.1")
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
const val mockitoVersion = "4.5.1"

dependencies {
    testImplementation("org.mockito:mockito-core:$mockitoVersion")
    testImplementation("org.mockito:mockito-inline:$mockitoVersion")
}
</pre>
<p>Alternatively, you can put <code>const val mockitoVersion = "4.5.1"</code> in any <code>.kt</code> file in <code>buildSrc/src/main/kotlin</code> or
use a more robust dependency management mechanism like <a href="https://plugins.gradle.org/plugin/io.spring.dependency-management">Spring dependency
management plugin</a> or <a href="https://www.youtube.com/watch?v=WvtcCCCLfOc&amp;list=PL0UJI1nZ56yAHv9H9kZA6vat4N1kSRGis&amp;index=21">Version
Catalogs</a>.</p>
<p>In general hard-coded values is a well known bad practice that affects maintainability. In dependency management, this issue is even more critical
because there is the risk of accidentally having different versions for the same dependency in your configuration.</p>
<p>Keeping hard-coded dependency versions increases the cost of maintainability and complicates the update process.</p>

### These files were changed in the pull request:
#### build.gradle.kts
