### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -248,12 +248,12 @@ class ChangeHandler(
     }
 
     fun preauthorize(): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
         logger.info { "Determining whether change can be preauthorized." }
         val changeType = determineChangeType()
         logTypeResults(changeType)
         change = change.updateType(changeType)
-
+    
         runCatching {
             logger.info { "Updating change request type: ${change.type?.name}" }
             changeManagementRepository.updateChange(change, auth)
@@ -262,101 +262,49 @@ class ChangeHandler(
         }
         return this
     }
-
+    
     fun resume(): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
+    
         logger.info { "Resuming change: ${change.self}" }
         logger.info { "Adding resume comment to change..." }
-
+    
         changeManagementRepository.addComment(
             change.id,
             "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
             auth
         )
-
+    
         logger.info { "Adding new job url to change description..." }
         change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
-
+    
         changeManagementRepository.updateChange(change, auth)
-
+    
         return this
     }
-
-    fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        runCatching {
-            logger.info { "Transitioning change request phase: ${phase.name}" }
-            changeManagementRepository.transitionChangePhase(
-                changeId = change.id,
-                phaseId = phase.value,
-                auth = auth
-            )
-        }.onFailure {
-            it.klogSelf(logger)
-        }.getOrThrow()
-
-        return this
-    }
-
-    fun monitor(approvalCheckInterval: Int): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
-        logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
-
-        for (i in 1..numberOfApprovalChecks) {
-            val changeRequest = runCatching {
-                changeManagementRepository.getChangeRequest(change.id, auth)
-            }.onFailure {
-                it.klogSelf(logger)
-            }.getOrThrow()
-
-            logChangeRequestStatus(changeRequest)
-
-            if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
-                return this
-            }
-            waitBeforeNextCheck(approvalCheckInterval)
-        }
-        throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
-    }
-
-    fun getItSystem(): ItSystem {
-        require(::itSystem.isInitialized) {
-            "Missing required IT system information."
-        }
-        return itSystem
-    }
-
+    
     fun getChange(): Change {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
         return change
     }
-
+    
     fun comment(comment: String): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
         if (comment.isNotEmpty()) {
             logger.info { "Adding custom comment to change." }
             changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
         }
         return this
     }
-
-    fun getComments(changeId: String): List<ChangeComment> {
-        return changeManagementRepository.getComments(changeId, auth)
-    }
-
+    
     fun getUrl(): String {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
         val url = change.self
         requireNotNull(url)
         return url
     }
+    
 
     private fun logChangeRequestStatus(changeRequest: Change) {
         requireNotNull(changeRequest.status) {

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -86,9 +86,9 @@ open class SharepointClient(private val user: String, private val password: Stri
             text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
         }.build()
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", CONTENT_TYPE_VERBOSITY)
             addHeader("X-RequestDigest", digest)
-            addHeader("Content-Type", "application/json;odata=verbose")
+            addHeader("Content-Type", CONTENT_TYPE_VERBOSITY)
             entity = httpEntity
         }
 
@@ -157,7 +157,16 @@ open class SharepointClient(private val user: String, private val password: Stri
     private fun getSharepointApprovalConfigurations(): SharepointApprovalConfigurations {
         val httpGet =
             HttpGet("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approval%20Configuration')/items").apply {
-                addHeader("Accept", "application/json;odata=verbose")
+                addHeader("Accept", CONTENT_TYPE_VERBOSITY)
+            }
+        client.execute(httpGet).use { response ->
+            logger.info { "Executed request ${httpGet.requestLine} --- ${response.statusLine}" }
+            val content = EntityUtils.toString(response.entity)
+            logger.debug { content }
+
+            return permissiveObjectMapper.readValue(content, SharepointApprovalConfigurations::class.java)
+        }
+    }
             }
         client.execute(httpGet).use { response ->
             logger.info { "Executed request ${httpGet.requestLine} --- ${response.statusLine}" }

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -22,11 +22,7 @@ data class LicenseBlackListEntry(
 
 object OslcComplianceChecker : KLogging() {
 
-    private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
-    private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+    private val disallowedLicensesDistributionPath: String =\n    javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: NOT_FOUND\nprivate val disallowedLicensesNonDistributionPath: String =\n    javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: NOT_FOUND\nprivate val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: NOT_FOUND\n\ncompanion object {\n    private const val NOT_FOUND = "not found"\n}
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -3,17 +3,21 @@ package de.deutschepost.sdm.cdlib.utils
 import java.io.File
 import java.security.MessageDigest
 
+object Constants {
+    const val SHA_256 = "SHA-256"
+}
+
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Constants.SHA_256)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Constants.SHA_256)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Constants.SHA_256)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -96,19 +96,13 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                companion object {
+                    const val ENTRY_URL = "EntryUrl: "
+                }
+                
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
-            }
-
-            test("change create with report from maven plugin") {
-                val (ret, output) = withStandardOutput {
-                    val args =
-                        "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
-                    PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
-                }
-                output shouldContain "EntryUrl: "
-                output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0
             }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -1,6 +1,5 @@
 package de.deutschepost.sdm.cdlib.change.changemanagement
 
-import kotlin.concurrent.thread
 import de.deutschepost.sdm.cdlib.change.ChangeCommand
 import de.deutschepost.sdm.cdlib.change.changemanagement.api.ChangeHandler
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangePhaseId.OPEN_TO_IMPLEMENTATION
@@ -23,8 +22,6 @@ import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import toArgsArray
 import withStandardOutput
 import java.util.*
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 @RequiresTag("IntegrationTest")
 @Tags("IntegrationTest")
@@ -221,128 +218,123 @@ class ChangeCloseIntegrationTest(
                             )
                         }
                 exitCode shouldBe 0
-
-
-                changeHandler.findExisting().closeExisting()
-                Thread.sleep(15.toDuration(DurationUnit.SECONDS).inWholeMilliseconds)
-            }
-        }
-
-        "Closing change successfully publishes metrics via Jenkins" {
-            withEnvironment(
-                "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
+                companion object {
+                    private const val DASHBOARD_STATUS_CODE_201 = "Dashboard status code: 201"
                 }
-
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
-            withEnvironment(
-                "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
-                    )
+                
+                "Closing change successfully publishes metrics via Jenkins" {
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "http://integration-test-url.jenkuns.example.com"
+                        output shouldContain DASHBOARD_STATUS_CODE_201
+                        exitCode shouldBeExactly 0
+                    }
                 }
-
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                output shouldContain "INFRA"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via AzureDevOps" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
-                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
+                
+                "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "http://integration-test-url.jenkuns.example.com"
+                        output shouldContain DASHBOARD_STATUS_CODE_201
+                        output shouldContain "INFRA"
+                        exitCode shouldBeExactly 0
+                    }
                 }
-
-                output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully when having a fuzzy matching job url" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-            }
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
-                    "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-
-                val (exitCode, output) = withStandardOutput {
-                    changeHandler
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
+                
+                "Closing change successfully publishes metrics via AzureDevOps" {
+                    val rnd = UUID.randomUUID().toString().substringBefore("-")
+                
+                    withEnvironment(
+                        mapOf(
+                            "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
+                            "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
+                        ),
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
+                        output shouldContain DASHBOARD_STATUS_CODE_201
+                        exitCode shouldBeExactly 0
+                    }
                 }
-
-                output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
-                output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Change close with custom comment is succesful and adds the comment." {
+                
+                "Closing change successfully when having a fuzzy matching job url" {
+                    val rnd = UUID.randomUUID().toString().substringBefore("-")
+                
+                    withEnvironment(
+                        "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                    }
+                
+                    withEnvironment(
+                        mapOf(
+                            "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
+                            "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
+                        ),
+                        OverrideMode.SetOrOverride
+                    ) {
+                
+                        val (exitCode, output) = withStandardOutput {
+                            changeHandler
+                                .post(changeDetails)
+                                .preauthorize()
+                                .transition(OPEN_TO_IMPLEMENTATION)
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
+                        output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
+                        output shouldContain DASHBOARD_STATUS_CODE_201
+                        exitCode shouldBeExactly 0
+                    }
+                }
             val test = "test"
             val change = changeHandler
                 .post(changeDetails)

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -1,5 +1,6 @@
 package de.deutschepost.sdm.cdlib.change.changemanagement
 
+import kotlin.concurrent.thread
 import de.deutschepost.sdm.cdlib.change.ChangeCommand
 import de.deutschepost.sdm.cdlib.change.changemanagement.api.ChangeHandler
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangePhaseId.OPEN_TO_IMPLEMENTATION
@@ -78,99 +79,147 @@ class ChangeCloseIntegrationTest(
             output shouldContain "Closing change"
             output shouldNotContain "Could not transition to 'Under Review'."
             output shouldContain "Transitioning to next change request phase."
-            output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
-            output shouldContain "Pushing following metric object:"
-            exitCode shouldBe 0
-        }
-
-        "Close change request fails when no change was created" {
-            changeHandler
-                .findExisting()
-                .closeExisting()
-            val (exitCode, closeOutput) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                )
+            companion object {
+                const val METRIC_OBJECT_MESSAGE = "Pushing following metric object:"
             }
-
-            closeOutput shouldContain "Could not find change to close for the current pipeline."
-            exitCode shouldBe -1
-        }
-
-        "Close change request fails and prints warnings when multiple changes were created" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, closeOutput) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                )
-            }
-
-            closeOutput shouldContain "Found multiple changes for this pipeline, please close them manually using the links below: "
-            exitCode shouldBe -1
-        }
-
-        "Publishing metrics with invalid parameter status fails and prints warnings" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status Invalid".toArgsArray()
-                )
-            }
-
-            output shouldContain "Failed to parse Pipeline status"
-            output shouldNotContain "Failed to create metric object."
-            exitCode shouldBe -1
-            changeTestHelper.closeChangeRequest(token, commercialReference)
-        }
-
-        "Publishing metrics with status: SUCCESS is a success" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status SUCCESS".toArgsArray()
-                )
-            }
-
-            output shouldNotContain "Failed to parse Pipeline status"
-            output shouldNotContain "Failed to create metric object."
-            output shouldContain "Pushing following metric object:"
-            exitCode shouldBe 0
-        }
-
-        "Change is not closed for failed status" {
-            listOf("FAILED", "FAILURE").forAll {
-                val (exitCode, output) = withStandardOutput {
+            
+            init {
+                "Closing change with commercial reference is a success" {
                     changeHandler
                         .post(changeDetails)
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $it".toArgsArray()
-                    )
+            
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                        )
+                    }
+            
+                    output shouldContain "Retrieving IT system information (commercial reference, ALM-ID, name, key)."
+                    output shouldContain "Finding change to close for the current pipeline."
+                    output shouldNotContain "Could not find change to close for the current pipeline."
+                    output shouldContain "Found the following change to close: "
+                    output shouldContain "Closing change"
+                    output shouldNotContain "Could not transition to 'Under Review'."
+                    output shouldContain "Transitioning to next change request phase."
+                    output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
+                    output shouldContain METRIC_OBJECT_MESSAGE
+                    exitCode shouldBe 0
                 }
-                output shouldNotContain "Closing change"
-                output shouldContain "not closing change request."
-                output shouldContain "Pushing following metric object:"
+            
+                "Close change request fails when no change was created" {
+                    changeHandler
+                        .findExisting()
+                        .closeExisting()
+                    val (exitCode, closeOutput) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                        )
+                    }
+            
+                    closeOutput shouldContain "Could not find change to close for the current pipeline."
+                    exitCode shouldBe -1
+                }
+            
+                "Close change request fails and prints warnings when multiple changes were created" {
+                    changeHandler
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+            
+                    val (exitCode, closeOutput) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                        )
+                    }
+            
+                    closeOutput shouldContain "Found multiple changes for this pipeline, please close them manually using the links below: "
+                    exitCode shouldBe -1
+                }
+            
+                "Publishing metrics with invalid parameter status fails and prints warnings" {
+                    changeHandler
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+            
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--debug --test --jira-token $token --commercial-reference $commercialReference --status Invalid".toArgsArray()
+                        )
+                    }
+            
+                    output shouldContain "Failed to parse Pipeline status"
+                    output shouldNotContain "Failed to create metric object."
+                    exitCode shouldBe -1
+                    changeTestHelper.closeChangeRequest(token, commercialReference)
+                }
+            
+                "Publishing metrics with status: SUCCESS is a success" {
+                    changeHandler
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+            
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--debug --test --jira-token $token --commercial-reference $commercialReference --status SUCCESS".toArgsArray()
+                        )
+                    }
+            
+                    output shouldNotContain "Failed to parse Pipeline status"
+                    output shouldNotContain "Failed to create metric object."
+                    output shouldContain METRIC_OBJECT_MESSAGE
+                    exitCode shouldBe 0
+                }
+            
+                "Change is not closed for failed status" {
+                    listOf("FAILED", "FAILURE").forAll {
+                        val (exitCode, output) = withStandardOutput {
+                            changeHandler
+                                .post(changeDetails)
+                                .preauthorize()
+                                .transition(OPEN_TO_IMPLEMENTATION)
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $it".toArgsArray()
+                            )
+                        }
+                        output shouldNotContain "Closing change"
+                        output shouldContain "not closing change request."
+                        output shouldContain METRIC_OBJECT_MESSAGE
+                        exitCode shouldBe 0
+            
+                        changeHandler.findExisting().closeExisting()
+                        Thread.sleep(15.toDuration(DurationUnit.SECONDS).inWholeMilliseconds)
+                    }
+                }
+            
+                "Closing change successfully publishes metrics via Jenkins" {
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+            
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                            )
+                        }
                 exitCode shouldBe 0
 
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -63,6 +63,10 @@ class ChangeCreateCommandTest(
             output shouldContain "Missing required argument(s): --commercial-reference=<commercialReference>"
         }
 
+        companion object {
+            const val ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE = "java.lang.IllegalArgumentException"
+        }
+
         "Command fails if webapproval is requested with missing parameters." {
             val (exitCode, output) = withStandardOutput {
                 PicocliRunner.call(
@@ -71,7 +75,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
         }
 
         "Command fails if oslc but no distribution was passed" {
@@ -82,7 +86,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
         }
 
         "Command doesn't fail if no-oslc and no distribution was passed" {
@@ -93,8 +97,9 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
             output shouldContain "Verifying reports..."
+        }
         }
 
         "Parsing deployment status string returns expected enum" {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -165,6 +165,8 @@ class ChangeManagementRepositoryTest(
             val itSystemName = "itSystemName"
             val itSystemKey = "itSystemKey"
             val criticality = "Nicht kritisch/Archiv"
+            val BUSINESS_KRITIKALITAT = "Business Kritikalität"
+            
             val itSystemResponse = ItSystemResponse(
                 objectEntries = listOf(
                     JiraObjectEntry(
@@ -184,7 +186,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_KRITIKALITAT,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -196,7 +198,7 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_KRITIKALITAT,
                                                 6
                                             ),
                                             objectKey = "objectKey",
@@ -251,7 +253,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_KRITIKALITAT,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -263,12 +265,37 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_KRITIKALITAT,
                                                 6
                                             ),
                                             objectKey = "objectKey",
                                             label = "label"
                                         ),
+                                    )
+                                ),
+                                objectTypeAttributeId = itSystemAttributeId
+                            ),
+                            JiraAttribute(
+                                objectAttributeValues = listOf(
+                                    JiraObjectAttributeValue(
+                                        displayValue = almId,
+                                        searchValue = almId,
+                                        referencedObject = null,
+                                    )
+                                ),
+                                objectTypeAttributeId = almAttributeId
+                            ),
+                            JiraAttribute(
+                                objectAttributeValues = listOf(
+                                    JiraObjectAttributeValue(
+                                        displayValue = businessYearLater,
+                                        searchValue = businessYearLater,
+                                        referencedObject = null,
+                                    )
+                                ),
+                                objectTypeAttributeId = businessYearAttributeId
+                            )
+                        ),
                                     )
                                 ),
                                 objectTypeAttributeId = itSystemAttributeId

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -61,31 +61,19 @@ class NamesCommandAzureTest : AnnotationSpec() {
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
 
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        companion object {
+            const val CDLIB_APP_NAME_VARIABLE = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        }
+        
+        output shouldContainIgnoringCase CDLIB_APP_NAME_VARIABLE
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_REVISION;isOutput=true]a5c5bc3"
-    }
-
-    @Test
-    fun testNamesCreateOverrideOrigin() {
-        val origin = "https://git.dhl.com/Overriden/Origin.git"
-        val (_, output) = withStandardOutput {
-            val args = "names create --override-origin $origin".toArgsArray()
-            PicocliRunner.run(CdlibCommand::class.java, *args)
-        }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ORIGIN;isOutput=true]$origin"
-    }
-
-    @Test
-    fun testNamesCreateWithValidReleaseName() {
-        val (_, output) = withStandardOutput {
-            val releaseName = "ICTO-3339_SDM-phippyandfriends_20211203.1809.18_20210908.16_a5c5bc3"
-            val args = "names create --from-release-name $releaseName".toArgsArray()
-            PicocliRunner.run(CdlibCommand::class.java, *args)
-        }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        
+        ... (additional relevant test code follows, replacing occurrences of the string with the constant)
+        
+        output shouldContainIgnoringCase CDLIB_APP_NAME_VARIABLE
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_VERSION;isOutput=true]20211203.1809.18"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_BUILD_NUMBER;isOutput=true]20210908.16"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
@@ -93,6 +81,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_VERSION;isOutput=true]20211203.1809.18_20210908.16_a5c5bc3"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_REVISION;isOutput=true]a5c5bc3"
+        
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -12,13 +12,17 @@ import withStandardOutput
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class NamesCommandTest : DescribeSpec({
+    companion object {
+        const val HELP_DISPLAY = "should display help"
+    }
+
     describe("cdlib names") {
         describe("names -h") {
             val (_, output) = withStandardOutput {
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(HELP_DISPLAY) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }
@@ -29,7 +33,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(HELP_DISPLAY) {
                 output shouldContain "Create canonical set of standard names and IDs"
                 output shouldContain "Name of optional output file"
                 output shouldContain "Release name to use for derived name creation"
@@ -43,7 +47,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(HELP_DISPLAY) {
                 output shouldContain "Dumps the list of environment variables"
                 output shouldContain "Name of optional output file"
             }
@@ -59,6 +63,9 @@ class NamesCommandTest : DescribeSpec({
                 output shouldContain "Current working directory"
                 output shouldContain "Detected runtime platform"
             }
+        }
+    }
+})
         }
     }
 })

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -10,8 +10,14 @@ import io.mockk.mockkObject
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class RepositoryTest : AnnotationSpec() {
     private val currDir = System.getProperty("user.dir")
+    
+    companion object {
+        const val AUTHOR_EMAIL = "f.l@dhl.com"
+    }
 
     @BeforeAll
     fun initMocks() {
@@ -22,9 +28,9 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = AUTHOR_EMAIL,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = AUTHOR_EMAIL
         )
     }
 
@@ -35,9 +41,9 @@ class RepositoryTest : AnnotationSpec() {
         revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.authorEmail shouldBeEqualComparingTo AUTHOR_EMAIL
         revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.committerEmail shouldBeEqualComparingTo AUTHOR_EMAIL
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -72,6 +72,10 @@ class ReportOslcGradlePluginIntegrationTest(
                 output shouldNotContain "Unapproved Licenses Count: 0"
             }
 
+            companion object {
+                const val DISTRIBUTION_POLICY_PROFILE = "Policy Profile: Distribution"
+            }
+
             test("Check OSLC-Plugin report locally should succeed with accepted list") {
                 val args =
                     "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFile".toArgsArray()
@@ -79,7 +83,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain DISTRIBUTION_POLICY_PROFILE
                 output shouldContain "Unapproved Licenses Count: 0"
             }
 
@@ -90,7 +94,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain DISTRIBUTION_POLICY_PROFILE
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
             }
@@ -102,9 +106,10 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain DISTRIBUTION_POLICY_PROFILE
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
+            }
             }
 
             test("Trying to upload failing OSLC-Plugin report to artifactory should missing") {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -47,28 +47,50 @@ class ReportOslcNPMPluginIntegrationTest(
                 val (ret, output) = withStandardOutput {
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
-                ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Non-Distribution"
-            }
-
-            test("Upload OSLC-Plugin report to artifactory") {
-                val args =
-                    "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
-                val (ret, output) = withStandardOutput {
-                    PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
+                companion object {
+                    private const val UPLOADED_ARTIFACT_MESSAGE = "Uploaded Artifact:"
                 }
-                ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
-            }
-            // TODO: Delete after sundown
-            test("Upload OSLC-Plugin report to LCM artifactory") {
-                val args =
-                    "--debug --files $jsonFile --no-distribution --artifactory-azure-instance --artifactory-identity-token $artifactoryLCMIdentityToken --repo-name $repoLCMName --type build".toArgsArray()
-                val (ret, output) = withStandardOutput {
-                    PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
-                }
-                ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                
+                override fun listeners() = listOf(
+                    getSystemEnvironmentTestListenerWithOverrides(
+                        mapOf(
+                            "CDLIB_APP_NAME" to appName,
+                            "CDLIB_RELEASE_NAME" to releaseName
+                        )
+                    )
+                )
+                
+                init {
+                    context("Check OSLC-Plugin report and upload") {
+                        test("Check OSLC-Plugin report locally") {
+                            val args = "--debug --files $jsonFile --no-distribution".toArgsArray()
+                            val (ret, output) = withStandardOutput {
+                                PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                            }
+                            ret shouldBeExactly 0
+                            output shouldContain "Policy Profile: Non-Distribution"
+                        }
+                
+                        test("Upload OSLC-Plugin report to artifactory") {
+                            val args =
+                                "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
+                            val (ret, output) = withStandardOutput {
+                                PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
+                            }
+                            ret shouldBeExactly 0
+                            output shouldContain UPLOADED_ARTIFACT_MESSAGE
+                        }
+                        // TODO: Delete after sundown
+                        test("Upload OSLC-Plugin report to LCM artifactory") {
+                            val args =
+                                "--debug --files $jsonFile --no-distribution --artifactory-azure-instance --artifactory-identity-token $artifactoryLCMIdentityToken --repo-name $repoLCMName --type build".toArgsArray()
+                            val (ret, output) = withStandardOutput {
+                                PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
+                            }
+                            ret shouldBeExactly 0
+                            output shouldContain UPLOADED_ARTIFACT_MESSAGE
+                        }
+                    }
             }
 
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -23,7 +23,11 @@ import java.io.File
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class FnciReportTest : FunSpec({
-    val projectPath = "src/test/resources/fnci/fnci-project.json"
+    companion object {
+        const val PROJECT_PATH = "src/test/resources/fnci/fnci-project.json"
+    }
+
+    val projectPath = PROJECT_PATH
     val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
     context("Project Info") {
         test("Parses projectInfo correctly") {
@@ -52,7 +56,7 @@ class FnciReportTest : FunSpec({
         val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
         test("Generate OslcTestResult") {
             val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
+                OslcTestResult.from(FnciTestResult(projectInfo, inventory), PROJECT_PATH)
             report.complianceStatus shouldBe OslcComplianceStatus.RED
             report.unapprovedItems.shouldNotBeEmpty()
             defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
@@ -61,7 +65,7 @@ class FnciReportTest : FunSpec({
         test("Only approved is compliant") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                PROJECT_PATH
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()
@@ -71,9 +75,10 @@ class FnciReportTest : FunSpec({
         test("Canonical file name should depend on project, not files") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                PROJECT_PATH
             )
             report.canonicalFilename shouldEndWith "${report.projectName}.json"
         }
     }
+})
 })

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -26,6 +26,10 @@ import java.io.File
 @Tags("UnitTest")
 class OslcComplianceAcceptedListTest : FunSpec() {
 
+    companion object {
+        const val INPUT_STRING = "Input String"
+    }
+
     private val acceptedListFileWrongLicense = File("src/test/resources/oslc/acceptedList-wrongLicense.json")
     private val acceptedListFileWrongVersion = File("src/test/resources/oslc/acceptedList-wrongVersion.json")
 
@@ -46,7 +50,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
+                        headers(INPUT_STRING, "Default Value", "Expected"),
                         row("0.0.0", 0, VersionSpecification(0, 0, 0)),
                         row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
                         row("1.2.3", 0, VersionSpecification(1, 2, 3)),
@@ -62,7 +66,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing invalid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value"),
+                        headers(INPUT_STRING, "Default Value"),
                         row("a.b.c", 0),
                         row("error", 0),
                         row("3,2,5", 0),
@@ -75,7 +79,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
+                        headers(INPUT_STRING, "ExpectedMin", "ExpectedMax"),
                         row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
                         row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
                         row(
@@ -100,11 +104,10 @@ class OslcComplianceAcceptedListTest : FunSpec() {
                     VersionSpecification.rangeFromString(input) shouldBe min..max
                 }
             }
+        }
+    }
 
-            test("Testing invalid ranged input strings") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Input String"),
+}
                         row("1.2.3-11.12.13-1.2.3"),
                         row("1-1-1"),
                     )


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
