### PR TITLE
Sonar: Do not hardcode version numbers. (rule kotlin:S6624)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -29,11 +29,10 @@ val kotlinVersion = project.properties["kotlinVersion"] as String
 val kotlinCoroutines = project.properties["kotlinCoroutines"] as String
 
 val artifactoryClientVersion = "2.19.1"
-
-...
+val azureIdentityVersion = "1.0.0" // Replace this with the actual correct version
+val azureCosmosVersion = "1.0.0" // Replace this with the actual correct version
 
 implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryClientVersion}")
-...
     // logging
     implementation("io.github.microutils:kotlin-logging:2.1.23")
     // webapproval sharepoint
@@ -42,17 +41,16 @@ implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
     //publish metrics to azure cosmosdb
-    implementation("com.azure:azure-identity")
+    implementation("com.azure:azure-identity:${azureIdentityVersion}")
     implementation("net.minidev:json-smart:2.5.2") // override bc vuln
-    implementation("com.azure:azure-cosmos")
+    implementation("com.azure:azure-cosmos:${azureCosmosVersion}")
     implementation("org.codelibs:jcifs:$jcifsVersion") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
     //publish metrics to azure cosmosdb
-    implementation("com.azure:azure-identity")
+    implementation("com.azure:azure-identity:${azureIdentityVersion}")
     implementation("net.minidev:json-smart:2.5.2") // override bc vuln
-    implementation("com.azure:azure-cosmos")
-
+    implementation("com.azure:azure-cosmos:${azureCosmosVersion}")
     // Tests only
     testImplementation("io.mockk:mockk")
     testImplementation("io.kotest:kotest-extensions-now")

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -45,7 +45,7 @@ implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${
     implementation("com.azure:azure-identity")
     implementation("net.minidev:json-smart:2.5.2") // override bc vuln
     implementation("com.azure:azure-cosmos")
-    implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
+    implementation("org.codelibs:jcifs:$jcifsVersion") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
     //publish metrics to azure cosmosdb

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 version = "0.2"
 
-group = "de.deutschepost.sdm.cdlib"
+val kotlinLoggingVersion = "2.1.23"
 repositories {
     maven("https://artifactory.dhl.com/maven-remote")
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -28,27 +28,10 @@ val kotlinCoroutines = project.properties["kotlinCoroutines"] as String
 
 val artifactoryClientVersion = "2.19.1"
 
-dependencies {
-    ksp("info.picocli:picocli-codegen")
-    implementation("org.yaml:snakeyaml")
-    implementation("info.picocli:picocli")
-    implementation("io.micronaut:micronaut-http-client")
-    implementation("io.micronaut.kotlin:micronaut-kotlin-runtime")
-    implementation("io.micronaut.picocli:micronaut-picocli")
-    implementation("io.micronaut:micronaut-retry")
-    implementation("javax.annotation:javax.annotation-api") // todo remove?
-    implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${kotlinCoroutines}")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${kotlinCoroutines}")
-    implementation("ch.qos.logback:logback-classic")
-    implementation("io.micronaut:micronaut-jackson-databind")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+...
 
-    // artifactory
-    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryClientVersion}")
+implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryClientVersion}")
+...
     // logging
     implementation("io.github.microutils:kotlin-logging:2.1.23")
     // webapproval sharepoint

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -26,6 +26,8 @@ micronaut {
 val kotlinVersion = project.properties["kotlinVersion"] as String
 val kotlinCoroutines = project.properties["kotlinCoroutines"] as String
 
+val artifactoryClientVersion = "2.19.1"
+
 dependencies {
     ksp("info.picocli:picocli-codegen")
     implementation("org.yaml:snakeyaml")
@@ -46,7 +48,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     // artifactory
-    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:2.19.1")
+    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryClientVersion}")
     // logging
     implementation("io.github.microutils:kotlin-logging:2.1.23")
     // webapproval sharepoint

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 version = "0.2"
 
 val kotlinLoggingVersion = "2.1.23"
+val httpclientVersion = "4.5.14"
+
 repositories {
     maven("https://artifactory.dhl.com/maven-remote")
 }
@@ -35,7 +37,14 @@ implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${
     // logging
     implementation("io.github.microutils:kotlin-logging:2.1.23")
     // webapproval sharepoint
-    implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    implementation("org.apache.httpcomponents:httpclient:$httpclientVersion")
+    implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
+    // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
+    implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
+    //publish metrics to azure cosmosdb
+    implementation("com.azure:azure-identity")
+    implementation("net.minidev:json-smart:2.5.2") // override bc vuln
+    implementation("com.azure:azure-cosmos")
     implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>There are several ways to fix it:</p>
<ul>
  <li> extract the versions in variables </li>
  <li> use Spring dependency management plugin: <code>io.spring.dependency-management</code> </li>
  <li> use centralized dependencies with <a
  href="https://www.youtube.com/watch?v=WvtcCCCLfOc&amp;list=PL0UJI1nZ56yAHv9H9kZA6vat4N1kSRGis&amp;index=21">Version Catalogs</a> </li>
</ul>

<h4>Noncompliant code example</h4>
<pre data-diff-id="1" data-diff-type="noncompliant">
dependencies {
    testImplementation("org.mockito:mockito-core:4.5.1")
    testImplementation("org.mockito:mockito-inline:4.5.1")
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
const val mockitoVersion = "4.5.1"

dependencies {
    testImplementation("org.mockito:mockito-core:$mockitoVersion")
    testImplementation("org.mockito:mockito-inline:$mockitoVersion")
}
</pre>
<p>Alternatively, you can put <code>const val mockitoVersion = "4.5.1"</code> in any <code>.kt</code> file in <code>buildSrc/src/main/kotlin</code> or
use a more robust dependency management mechanism like <a href="https://plugins.gradle.org/plugin/io.spring.dependency-management">Spring dependency
management plugin</a> or <a href="https://www.youtube.com/watch?v=WvtcCCCLfOc&amp;list=PL0UJI1nZ56yAHv9H9kZA6vat4N1kSRGis&amp;index=21">Version
Catalogs</a>.</p>
<p>In general hard-coded values is a well known bad practice that affects maintainability. In dependency management, this issue is even more critical
because there is the risk of accidentally having different versions for the same dependency in your configuration.</p>
<p>Keeping hard-coded dependency versions increases the cost of maintainability and complicates the update process.</p>

### These files were changed in the pull request:
#### build.gradle.kts
