### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -248,111 +248,116 @@ class ChangeHandler(
     }
 
     fun preauthorize(): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
-        logger.info { "Determining whether change can be preauthorized." }
-        val changeType = determineChangeType()
-        logTypeResults(changeType)
-        change = change.updateType(changeType)
-
-        runCatching {
-            logger.info { "Updating change request type: ${change.type?.name}" }
-            changeManagementRepository.updateChange(change, auth)
-        }.getOrElse {
-            logger.error { "Could not update change request type. \nError: ${it.message}" }
+        companion object {
+            const val MISSING_CHANGE_INFO = "Missing required change information."
         }
-        return this
-    }
-
-    fun resume(): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        logger.info { "Resuming change: ${change.self}" }
-        logger.info { "Adding resume comment to change..." }
-
-        changeManagementRepository.addComment(
-            change.id,
-            "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
-            auth
-        )
-
-        logger.info { "Adding new job url to change description..." }
-        change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
-
-        changeManagementRepository.updateChange(change, auth)
-
-        return this
-    }
-
-    fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        runCatching {
-            logger.info { "Transitioning change request phase: ${phase.name}" }
-            changeManagementRepository.transitionChangePhase(
-                changeId = change.id,
-                phaseId = phase.value,
-                auth = auth
+        
+        fun preauthorize(): ChangeHandler {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+            logger.info { "Determining whether change can be preauthorized." }
+            val changeType = determineChangeType()
+            logTypeResults(changeType)
+            change = change.updateType(changeType)
+        
+            runCatching {
+                logger.info { "Updating change request type: ${change.type?.name}" }
+                changeManagementRepository.updateChange(change, auth)
+            }.getOrElse {
+                logger.error { "Could not update change request type. \nError: ${it.message}" }
+            }
+            return this
+        }
+        
+        fun resume(): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+        
+            logger.info { "Resuming change: ${change.self}" }
+            logger.info { "Adding resume comment to change..." }
+        
+            changeManagementRepository.addComment(
+                change.id,
+                "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
+                auth
             )
-        }.onFailure {
-            it.klogSelf(logger)
-        }.getOrThrow()
-
-        return this
-    }
-
-    fun monitor(approvalCheckInterval: Int): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
-        logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
-
-        for (i in 1..numberOfApprovalChecks) {
-            val changeRequest = runCatching {
-                changeManagementRepository.getChangeRequest(change.id, auth)
+        
+            logger.info { "Adding new job url to change description..." }
+            change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
+        
+            changeManagementRepository.updateChange(change, auth)
+        
+            return this
+        }
+        
+        fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+        
+            runCatching {
+                logger.info { "Transitioning change request phase: ${phase.name}" }
+                changeManagementRepository.transitionChangePhase(
+                    changeId = change.id,
+                    phaseId = phase.value,
+                    auth = auth
+                )
             }.onFailure {
                 it.klogSelf(logger)
             }.getOrThrow()
-
-            logChangeRequestStatus(changeRequest)
-
-            if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
-                return this
+        
+            return this
+        }
+        
+        fun monitor(approvalCheckInterval: Int): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+        
+            val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
+            logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
+        
+            for (i in 1..numberOfApprovalChecks) {
+                val changeRequest = runCatching {
+                    changeManagementRepository.getChangeRequest(change.id, auth)
+                }.onFailure {
+                    it.klogSelf(logger)
+                }.getOrThrow()
+        
+                logChangeRequestStatus(changeRequest)
+        
+                if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
+                    return this
+                }
+                waitBeforeNextCheck(approvalCheckInterval)
             }
-            waitBeforeNextCheck(approvalCheckInterval)
+            throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
         }
-        throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
-    }
-
-    fun getItSystem(): ItSystem {
-        require(::itSystem.isInitialized) {
-            "Missing required IT system information."
+        
+        fun getItSystem(): ItSystem {
+            require(::itSystem.isInitialized) {
+                "Missing required IT system information."
+            }
+            return itSystem
         }
-        return itSystem
-    }
-
-    fun getChange(): Change {
-        require(::change.isInitialized) { "Missing required change information." }
-        return change
-    }
-
-    fun comment(comment: String): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
-        if (comment.isNotEmpty()) {
-            logger.info { "Adding custom comment to change." }
-            changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
+        
+        fun getChange(): Change {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+            return change
         }
-        return this
-    }
-
-    fun getComments(changeId: String): List<ChangeComment> {
-        return changeManagementRepository.getComments(changeId, auth)
-    }
-
-    fun getUrl(): String {
-        require(::change.isInitialized) { "Missing required change information." }
+        
+        fun comment(comment: String): ChangeHandler {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+            if (comment.isNotEmpty()) {
+                logger.info { "Adding custom comment to change." }
+                changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
+            }
+            return this
+        }
+        
+        fun getComments(changeId: String): List<ChangeComment> {
+            return changeManagementRepository.getComments(changeId, auth)
+        }
+        
+        fun getUrl(): String {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
         val url = change.self
         requireNotNull(url)
         return url

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -41,73 +41,80 @@ open class SharepointClient(private val user: String, private val password: Stri
 
     private fun getDigest(): String? {
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/contextinfo").apply {
-            addHeader("Accept", "application/json;odata=verbose")
-        }
-        return client.execute(httpPost).use { response ->
-            logger.info { "Getting Sharepoint Digest: ${response.statusLine}" }
-            val content = EntityUtils.toString(response.entity)
-            logger.debug { content }
-            if (response.statusLine.statusCode == HttpStatus.SC_OK) {
-                val sharepointContextWebInformation =
-                    permissiveObjectMapper.readValue(content, SharepointContextWebInformation::class.java)
-                sharepointContextWebInformation.getDigest()
-            } else {
-                null
+            companion object {
+                private const val APPLICATION_JSON_ODATA_VERBOSE = "application/json;odata=verbose"
             }
-        }
-    }
-
-    fun addEntryProd(approvalsListItem: SharepointApprovalsListItem) =
-        addEntry(approvalsListItem, ISHARE_PROD_LIST)
-
-    fun addEntryTest(approvalsListItem: SharepointApprovalsListItem): Webapproval {
-        val approvalsListItemTest = approvalsListItem.copy(metadata = SharepointApprovalsListItem.Metadata.TEST)
-        return addEntry(approvalsListItemTest, ISHARE_TEST_LIST)
-    }
-
-    private fun addEntry(
-        approvalsListItem: SharepointApprovalsListItem,
-        listName: String,
-    ): Webapproval {
-        val digest =
-            checkNotNull(getDigest()) {
-                """
-                Failed to get digest for Record.
-                This is eiter a connection issue or a credentials issue. You can check this with following command:
-                curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: application/json;odata=verbose\"""".trimIndent()
+            
+            private fun getDigest(): String? {
+                val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/contextinfo").apply {
+                    addHeader("Accept", APPLICATION_JSON_ODATA_VERBOSE)
+                }
+                return client.execute(httpPost).use { response ->
+                    logger.info { "Getting Sharepoint Digest: ${response.statusLine}" }
+                    val content = EntityUtils.toString(response.entity)
+                    logger.debug { content }
+                    if (response.statusLine.statusCode == HttpStatus.SC_OK) {
+                        val sharepointContextWebInformation =
+                            permissiveObjectMapper.readValue(content, SharepointContextWebInformation::class.java)
+                        sharepointContextWebInformation.getDigest()
+                    } else {
+                        null
+                    }
+                }
             }
-
-        val webapprovalWithoutURL =
-            checkNotNull(verifyAndGenerateWebapproval(approvalsListItem.applicationId, listName == ISHARE_TEST_LIST)) {
-                "Failed validating approval documents."
+            
+            fun addEntryProd(approvalsListItem: SharepointApprovalsListItem) =
+                addEntry(approvalsListItem, ISHARE_PROD_LIST)
+            
+            fun addEntryTest(approvalsListItem: SharepointApprovalsListItem): Webapproval {
+                val approvalsListItemTest = approvalsListItem.copy(metadata = SharepointApprovalsListItem.Metadata.TEST)
+                return addEntry(approvalsListItemTest, ISHARE_TEST_LIST)
             }
-
-        val httpEntity = EntityBuilder.create().apply {
-            text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
-        }.build()
-        val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
-            addHeader("Accept", "application/json;odata=verbose")
-            addHeader("X-RequestDigest", digest)
-            addHeader("Content-Type", "application/json;odata=verbose")
-            entity = httpEntity
-        }
-
-        val webapprovalUrl = client.execute(httpPost).use { response ->
-            logger.info { "Adding Record: ${response.statusLine}" }
-            val content = EntityUtils.toString(response.entity)
-            logger.debug { content }
-
-            if (response.statusLine.statusCode != HttpStatus.SC_CREATED) {
-                logger.error { content }
-                throw IllegalStateException("Failed to create Record.")
-            } else {
-                val sharepointListItemId =
-                    permissiveObjectMapper.readValue(content, SharepointApprovalListItemId::class.java)
-                sharepointListItemId.getUrl(ISHARE_WEBAPPROVAL_BASE_URL, listName)
+            
+            private fun addEntry(
+                approvalsListItem: SharepointApprovalsListItem,
+                listName: String,
+            ): Webapproval {
+                val digest =
+                    checkNotNull(getDigest()) {
+                        """
+                        Failed to get digest for Record.
+                        This is eiter a connection issue or a credentials issue. You can check this with following command:
+                        curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: APPLICATION_JSON_ODATA_VERBOSE\""".trimIndent()
+                    }
+            
+                val webapprovalWithoutURL =
+                    checkNotNull(verifyAndGenerateWebapproval(approvalsListItem.applicationId, listName == ISHARE_TEST_LIST)) {
+                        "Failed validating approval documents."
+                    }
+            
+                val httpEntity = EntityBuilder.create().apply {
+                    text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
+                }.build()
+                val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
+                    addHeader("Accept", APPLICATION_JSON_ODATA_VERBOSE)
+                    addHeader("X-RequestDigest", digest)
+                    addHeader("Content-Type", APPLICATION_JSON_ODATA_VERBOSE)
+                    entity = httpEntity
+                }
+            
+                val webapprovalUrl = client.execute(httpPost).use { response ->
+                    logger.info { "Adding Record: ${response.statusLine}" }
+                    val content = EntityUtils.toString(response.entity)
+                    logger.debug { content }
+            
+                    if (response.statusLine.statusCode != HttpStatus.SC_CREATED) {
+                        logger.error { content }
+                        throw IllegalStateException("Failed to create Record.")
+                    } else {
+                        val sharepointListItemId =
+                            permissiveObjectMapper.readValue(content, SharepointApprovalListItemId::class.java)
+                        sharepointListItemId.getUrl(ISHARE_WEBAPPROVAL_BASE_URL, listName)
+                    }
+                }
+                logger.info { "EntryUrl: $webapprovalUrl" }
+                return webapprovalWithoutURL.copy(url = webapprovalUrl)
             }
-        }
-        logger.info { "EntryUrl: $webapprovalUrl" }
-        return webapprovalWithoutURL.copy(url = webapprovalUrl)
     }
 
 

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -22,11 +22,16 @@ data class LicenseBlackListEntry(
 
 object OslcComplianceChecker : KLogging() {
 
+    companion object {
+        const val NOT_FOUND = "not found"
+    }
+
     private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: NOT_FOUND
     private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: NOT_FOUND
+    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: NOT_FOUND
+
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -3,17 +3,21 @@ package de.deutschepost.sdm.cdlib.utils
 import java.io.File
 import java.security.MessageDigest
 
+object HashUtils {
+    const val HASH_ALGORITHM = "SHA-256"
+}
+
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(HashUtils.HASH_ALGORITHM)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(HashUtils.HASH_ALGORITHM)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(HashUtils.HASH_ALGORITHM)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -79,6 +79,10 @@ class ChangeOslcIntegrationTest(
     }
 
     init {
+        companion object {
+            const val ENTRY_URL = "EntryUrl: "
+        }
+
         context("Creating oslc change is a success") {
             test("change create --oslc missing distribution") {
                 val (ret, output) = withStandardOutput {
@@ -96,7 +100,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
             }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -200,33 +200,55 @@ class ChangeCloseIntegrationTest(
                     )
                 }
 
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
-            withEnvironment(
-                "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
-                    )
+                companion object {
+                    const val STATUS_CODE_MESSAGE = "Dashboard status code: 201"
                 }
-
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                output shouldContain "INFRA"
-                exitCode shouldBeExactly 0
+                
+                "Closing change successfully publishes metrics via Jenkins" {
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "http://integration-test-url.jenkuns.example.com"
+                        output shouldContain STATUS_CODE_MESSAGE
+                        exitCode shouldBeExactly 0
+                    }
+                }
+                
+                "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                
+                        val (exitCode, output) = withStandardOutput {
+                            PicocliRunner.call(
+                                ChangeCommand.CloseCommand::class.java,
+                                *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
+                            )
+                        }
+                
+                        output shouldContain "http://integration-test-url.jenkuns.example.com"
+                        output shouldContain STATUS_CODE_MESSAGE
+                        output shouldContain "INFRA"
+                        exitCode shouldBeExactly 0
+                    }
             }
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -58,6 +58,10 @@ class ChangeCloseIntegrationTest(
     )
 
     init {
+        companion object {
+            const val METRIC_OBJECT_MESSAGE = "Pushing following metric object:"
+        }
+
         "Closing change with commercial reference is a success" {
             changeHandler
                 .post(changeDetails)
@@ -79,7 +83,7 @@ class ChangeCloseIntegrationTest(
             output shouldNotContain "Could not transition to 'Under Review'."
             output shouldContain "Transitioning to next change request phase."
             output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain METRIC_OBJECT_MESSAGE
             exitCode shouldBe 0
         }
 
@@ -152,7 +156,7 @@ class ChangeCloseIntegrationTest(
 
             output shouldNotContain "Failed to parse Pipeline status"
             output shouldNotContain "Failed to create metric object."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain METRIC_OBJECT_MESSAGE
             exitCode shouldBe 0
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -70,8 +70,12 @@ class ChangeCreateCommandTest(
                     *"--jira-token $token --debug --commercial-reference 5296 --test --webapproval --no-distribution".toArgsArray()
                 )
             }
+            private companion object {
+                const val ILLEGAL_ARGUMENT_EXCEPTION = "java.lang.IllegalArgumentException"
+            }
+
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
         }
 
         "Command fails if oslc but no distribution was passed" {
@@ -82,7 +86,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
         }
 
         "Command doesn't fail if no-oslc and no distribution was passed" {
@@ -93,7 +97,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
             output shouldContain "Verifying reports..."
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -165,6 +165,10 @@ class ChangeManagementRepositoryTest(
             val itSystemName = "itSystemName"
             val itSystemKey = "itSystemKey"
             val criticality = "Nicht kritisch/Archiv"
+            object ItSystemConstants {
+                const val BUSINESS_KRITIKALITAT = "Business Kritikalität"
+            }
+            
             val itSystemResponse = ItSystemResponse(
                 objectEntries = listOf(
                     JiraObjectEntry(
@@ -184,7 +188,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = ItSystemConstants.BUSINESS_KRITIKALITAT,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -196,7 +200,7 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = ItSystemConstants.BUSINESS_KRITIKALITAT,
                                                 6
                                             ),
                                             objectKey = "objectKey",
@@ -251,7 +255,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = ItSystemConstants.BUSINESS_KRITIKALITAT,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -263,12 +267,37 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = ItSystemConstants.BUSINESS_KRITIKALITAT,
                                                 6
                                             ),
                                             objectKey = "objectKey",
                                             label = "label"
                                         ),
+                                    )
+                                ),
+                                objectTypeAttributeId = itSystemAttributeId
+                            ),
+                            JiraAttribute(
+                                objectAttributeValues = listOf(
+                                    JiraObjectAttributeValue(
+                                        displayValue = almId,
+                                        searchValue = almId,
+                                        referencedObject = null,
+                                    )
+                                ),
+                                objectTypeAttributeId = almAttributeId
+                            ),
+                            JiraAttribute(
+                                objectAttributeValues = listOf(
+                                    JiraObjectAttributeValue(
+                                        displayValue = businessYearLater,
+                                        searchValue = businessYearLater,
+                                        referencedObject = null,
+                                    )
+                                ),
+                                objectTypeAttributeId = businessYearAttributeId
+                            )
+                        ),
                                     )
                                 ),
                                 objectTypeAttributeId = itSystemAttributeId

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
@@ -30,38 +30,44 @@ class NameResolverAzureTest(
     private val namesConfigWithDefault: NamesConfigWithDefault
 ) : AnnotationSpec() {
     private val before = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toInstant()
-
-
-    override fun listeners() = listOf(
-        SystemEnvironmentTestListener(
-            mapOf(
-                "BUILD_BUILDID" to "12657",
-                "BUILD_DEFINITIONNAME" to "ICTO-3339_SDM-phippyandfriends",
-                "BUILD_SOURCEBRANCHNAME" to "i593_test",
-                "SYSTEM_COLLECTIONURI" to "https://dev.azure.com/sw-zustellung-31b3183/",
-                "SYSTEM_TEAMPROJECT" to "ICTO-3339_SDM",
-                "TF_BUILD" to "True",
-                "SYSTEM_DEFINITIONID" to "912345",
-                "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "i593_test"
-            ),
-            OverrideMode.SetOrOverride
+    class NameResolverAzureTest(
+        private val resolver: NameResolverAzure,
+        private val namesConfigWithDefault: NamesConfigWithDefault
+    ) : AnnotationSpec() {
+        companion object {
+            const val DEFAULT_DEFINITION_NAME = "ICTO-3339_SDM-phippyandfriends"
+        }
+    
+        override fun listeners() = listOf(
+            SystemEnvironmentTestListener(
+                mapOf(
+                    "BUILD_BUILDID" to "12657",
+                    "BUILD_DEFINITIONNAME" to DEFAULT_DEFINITION_NAME,
+                    "BUILD_SOURCEBRANCHNAME" to "i593_test",
+                    "SYSTEM_COLLECTIONURI" to "https://dev.azure.com/sw-zustellung-31b3183/",
+                    "SYSTEM_TEAMPROJECT" to "ICTO-3339_SDM",
+                    "TF_BUILD" to "True",
+                    "SYSTEM_DEFINITIONID" to "912345",
+                    "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "i593_test"
+                ),
+                OverrideMode.SetOrOverride
+            )
         )
-    )
-
-    @BeforeAll
-    fun initMocks() {
-        mockkObject(GitRepository)
-        every { GitRepository.getRemoteUrl(any()) } returns "https://git.dhl.com/CDLib/CDLib.git"
-        every { GitRepository.lastBranchCommit(any()) } returns GitRevision(
-            id = "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
-            longMessage = "Dummy \"Commit\"",
-            shortMessage = "Dummy \$Commit",
-            authorName = "Firstname Author",
-            authorEmail = "f.a@dhl.com",
-            committerName = "Firstname Committer",
-            committerEmail = "f.c@dhl.com"
-        )
-    }
+    
+        @BeforeAll
+        fun initMocks() {
+            mockkObject(GitRepository)
+            every { GitRepository.getRemoteUrl(any()) } returns "https://git.dhl.com/CDLib/CDLib.git"
+            every { GitRepository.lastBranchCommit(any()) } returns GitRevision(
+                id = "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
+                longMessage = "Dummy \"Commit\"",
+                shortMessage = "Dummy \$Commit",
+                authorName = "Firstname Author",
+                authorEmail = "f.a@dhl.com",
+                committerName = "Firstname Committer",
+                committerEmail = "f.c@dhl.com"
+            )
+        }
 
     @Test
     fun testCreate_sanitizedTruncated() {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -60,8 +60,8 @@ class NamesCommandAzureTest : AnnotationSpec() {
             val args = "names create".toArgsArray()
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
-
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+    
+        output shouldContainIgnoringCase CDLIB_APP_NAME_VARIABLE
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -18,7 +18,7 @@ class NamesCommandTest : DescribeSpec({
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(SHOULD_DISPLAY_HELP) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }
@@ -29,7 +29,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(SHOULD_DISPLAY_HELP) {
                 output shouldContain "Create canonical set of standard names and IDs"
                 output shouldContain "Name of optional output file"
                 output shouldContain "Release name to use for derived name creation"
@@ -43,7 +43,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(SHOULD_DISPLAY_HELP) {
                 output shouldContain "Dumps the list of environment variables"
                 output shouldContain "Name of optional output file"
             }
@@ -60,5 +60,9 @@ class NamesCommandTest : DescribeSpec({
                 output shouldContain "Detected runtime platform"
             }
         }
+    }
+
+    companion object {
+        private const val SHOULD_DISPLAY_HELP = "should display help"
     }
 })

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -13,6 +13,10 @@ import io.mockk.mockkObject
 class RepositoryTest : AnnotationSpec() {
     private val currDir = System.getProperty("user.dir")
 
+    companion object {
+        const val AUTHOR_EMAIL = "f.l@dhl.com"
+    }
+
     @BeforeAll
     fun initMocks() {
         mockkObject(GitRepository)
@@ -22,10 +26,11 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = AUTHOR_EMAIL,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = AUTHOR_EMAIL
         )
+    }
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -68,44 +68,54 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
-                output shouldNotContain "Unapproved Licenses Count: 0"
-            }
-
-            test("Check OSLC-Plugin report locally should succeed with accepted list") {
-                val args =
-                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFile".toArgsArray()
-                val (ret, output) = withStandardOutput {
-                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                companion object {
+                    const val POLICY_PROFILE_DISTRIBUTION = "Policy Profile: Distribution"
                 }
-                ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
-                output shouldContain "Unapproved Licenses Count: 0"
-            }
-
-            test("Check OSLC-Plugin report locally should fail with accepted list because of wrong license") {
-                val args =
-                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongLicense".toArgsArray()
-                val (ret, output) = withStandardOutput {
-                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
-                }
-                ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
-                output shouldContain "Unapproved Licenses Count: 1"
-                output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
-            }
-
-            test("Check OSLC-Plugin report locally should fail with accepted list because of wrong version number") {
-                val args =
-                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongVersion".toArgsArray()
-                val (ret, output) = withStandardOutput {
-                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
-                }
-                ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
-                output shouldContain "Unapproved Licenses Count: 1"
-                output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
-            }
+                
+                            test("Check OSLC-Plugin report locally should fail due to distribution flag") {
+                                val args = "--debug --files $jsonFile --distribution".toArgsArray()
+                                val (ret, output) = withStandardOutput {
+                                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                                }
+                                ret shouldBeExactly -1
+                                output shouldContain POLICY_PROFILE_DISTRIBUTION
+                                output shouldNotContain "Unapproved Licenses Count: 0"
+                            }
+                
+                            test("Check OSLC-Plugin report locally should succeed with accepted list") {
+                                val args =
+                                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFile".toArgsArray()
+                                val (ret, output) = withStandardOutput {
+                                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                                }
+                                ret shouldBeExactly 0
+                                output shouldContain POLICY_PROFILE_DISTRIBUTION
+                                output shouldContain "Unapproved Licenses Count: 0"
+                            }
+                
+                            test("Check OSLC-Plugin report locally should fail with accepted list because of wrong license") {
+                                val args =
+                                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongLicense".toArgsArray()
+                                val (ret, output) = withStandardOutput {
+                                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                                }
+                                ret shouldBeExactly -1
+                                output shouldContain POLICY_PROFILE_DISTRIBUTION
+                                output shouldContain "Unapproved Licenses Count: 1"
+                                output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
+                            }
+                
+                            test("Check OSLC-Plugin report locally should fail with accepted list because of wrong version number") {
+                                val args =
+                                    "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongVersion".toArgsArray()
+                                val (ret, output) = withStandardOutput {
+                                    PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
+                                }
+                                ret shouldBeExactly -1
+                                output shouldContain POLICY_PROFILE_DISTRIBUTION
+                                output shouldContain "Unapproved Licenses Count: 1"
+                                output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
+                            }
 
             test("Trying to upload failing OSLC-Plugin report to artifactory should missing") {
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -51,6 +51,10 @@ class ReportOslcNPMPluginIntegrationTest(
                 output shouldContain "Policy Profile: Non-Distribution"
             }
 
+            companion object {
+                const val UPLOADED_ARTIFACT_MESSAGE = "Uploaded Artifact:"
+            }
+
             test("Upload OSLC-Plugin report to artifactory") {
                 val args =
                     "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
@@ -58,7 +62,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT_MESSAGE
             }
             // TODO: Delete after sundown
             test("Upload OSLC-Plugin report to LCM artifactory") {
@@ -68,7 +72,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT_MESSAGE
             }
 
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -23,8 +23,13 @@ import java.io.File
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class FnciReportTest : FunSpec({
-    val projectPath = "src/test/resources/fnci/fnci-project.json"
+    val projectPath = FNCI_PROJECT_JSON_PATH
     val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
+
+    companion object {
+        const val FNCI_PROJECT_JSON_PATH = "src/test/resources/fnci/fnci-project.json"
+    }
+
     context("Project Info") {
         test("Parses projectInfo correctly") {
             val projectInfo = permissiveObjectMapper.readValue(
@@ -52,7 +57,7 @@ class FnciReportTest : FunSpec({
         val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
         test("Generate OslcTestResult") {
             val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
+                OslcTestResult.from(FnciTestResult(projectInfo, inventory), FNCI_PROJECT_JSON_PATH)
             report.complianceStatus shouldBe OslcComplianceStatus.RED
             report.unapprovedItems.shouldNotBeEmpty()
             defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
@@ -61,7 +66,7 @@ class FnciReportTest : FunSpec({
         test("Only approved is compliant") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                FNCI_PROJECT_JSON_PATH
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()
@@ -71,7 +76,7 @@ class FnciReportTest : FunSpec({
         test("Canonical file name should depend on project, not files") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                FNCI_PROJECT_JSON_PATH
             )
             report.canonicalFilename shouldEndWith "${report.projectName}.json"
         }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -42,11 +42,15 @@ class OslcComplianceAcceptedListTest : FunSpec() {
     )
 
     init {
+        companion object {
+            const val HEADER_INPUT_STRING = "Input String"
+        }
+    
         context("de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.VersionSpecification parsing") {
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
+                        headers(HEADER_INPUT_STRING, "Default Value", "Expected"),
                         row("0.0.0", 0, VersionSpecification(0, 0, 0)),
                         row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
                         row("1.2.3", 0, VersionSpecification(1, 2, 3)),
@@ -58,11 +62,11 @@ class OslcComplianceAcceptedListTest : FunSpec() {
                     VersionSpecification.fromString(input, default) shouldBe expected
                 }
             }
-
+    
             test("Testing invalid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value"),
+                        headers(HEADER_INPUT_STRING, "Default Value"),
                         row("a.b.c", 0),
                         row("error", 0),
                         row("3,2,5", 0),
@@ -71,11 +75,11 @@ class OslcComplianceAcceptedListTest : FunSpec() {
                     shouldThrow<NumberFormatException> { VersionSpecification.fromString(input, default) }
                 }
             }
-
+    
             test("Testing valid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
+                        headers(HEADER_INPUT_STRING, "ExpectedMin", "ExpectedMax"),
                         row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
                         row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
                         row(

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
@@ -38,7 +38,8 @@ class OslcComplianceCheckerTest : FunSpec() {
             )
         )
     )
-    private val licenseMozillaName = "Mozilla Public License 2.0"
+    private val LICENSE_MOZILLA = "Mozilla Public License 2.0"
+    
     private val depWithCDDL = OslcDependencyLicenseEntry(
         dependencyName = "test.should.fail:cddl",
         dependencyVersion = "",


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
