### PR TITLE
Sonar: Remove this unused private "fileAndCheck" method. (rule kotlin:S1144)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/artifactory/ArtifactoryClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/artifactory/ArtifactoryClient.kt
@@ -361,11 +361,7 @@ class ArtifactoryClient(
             }
         }
 
-    private fun RepositoryHandle.fileAndCheck(path: String): ItemHandle =
-        file(path).also {
-            check(it.exists()) {
-                logger.error { "Could not find file: $path." }
-            }
+    
         }
 
     private fun RepositoryHandle.folderAndCheck(path: String): ItemHandle =


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 

<p>A function that is never called is dead code, and should be removed. Cleaning out dead code decreases the size of the maintained codebase, making
it easier to understand the program and preventing bugs from being introduced.</p>
<p>This rule detects functions that are never referenced from inside a translation unit, and cannot be referenced from the outside.</p>

<h3>Noncompliant code example</h3>
<pre data-diff-id="1" data-diff-type="noncompliant">
class Foo: Serializable {
  private fun unusedMethod() {...}
  private fun writeObject(s: ObjectOutputStream) {...}  // Compliant, relates to the serialization mechanism
  private fun readObject(s: ObjectOutputStream) {...}  // Compliant, relates to the serialization mechanism
}
</pre>
<h3>Compliant solution</h3>
<pre data-diff-id="1" data-diff-type="compliant">
class Foo: Serializable {
  private fun writeObject(s: ObjectOutputStream) {...}  // Compliant, relates to the serialization mechanism
  private fun readObject(s: ObjectOutputStream) {...}  // Compliant, relates to the serialization mechanism
}
</pre>
<h3>Exceptions</h3>
<p>This rule doesn’t raise issues for:</p>
<ul>
  <li> annotated methods </li>
  <li> methods with parameters that are annotated with <code>@javax.enterprise.event.Observes</code> </li>
</ul>
<p>The rule does not take reflection into account, which means that issues will be raised on <code>private</code> methods that are only accessed using
the reflection API.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/artifactory/ArtifactoryClient.kt
