### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -247,13 +247,17 @@ class ChangeHandler(
         return this
     }
 
+    companion object {
+        private const val MISSING_CHANGE_INFORMATION = "Missing required change information."
+    }
+    
     fun preauthorize(): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFORMATION }
         logger.info { "Determining whether change can be preauthorized." }
         val changeType = determineChangeType()
         logTypeResults(changeType)
         change = change.updateType(changeType)
-
+    
         runCatching {
             logger.info { "Updating change request type: ${change.type?.name}" }
             changeManagementRepository.updateChange(change, auth)
@@ -262,32 +266,32 @@ class ChangeHandler(
         }
         return this
     }
-
+    
     fun resume(): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
+        require(::change.isInitialized) { MISSING_CHANGE_INFORMATION }
+    
         logger.info { "Resuming change: ${change.self}" }
         logger.info { "Adding resume comment to change..." }
-
+    
         changeManagementRepository.addComment(
             change.id,
             "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
             auth
         )
-
+    
         logger.info { "Adding new job url to change description..." }
         change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
-
+    
         changeManagementRepository.updateChange(change, auth)
-
+    
         return this
     }
-
+    
     fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
+        require(::change.isInitialized) { MISSING_CHANGE_INFORMATION }
+    
         runCatching {
             logger.info { "Transitioning change request phase: ${phase.name}" }
             changeManagementRepository.transitionChangePhase(
@@ -298,26 +302,26 @@ class ChangeHandler(
         }.onFailure {
             it.klogSelf(logger)
         }.getOrThrow()
-
+    
         return this
     }
-
+    
     fun monitor(approvalCheckInterval: Int): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
+        require(::change.isInitialized) { MISSING_CHANGE_INFORMATION }
+    
         val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
         logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
-
+    
         for (i in 1..numberOfApprovalChecks) {
             val changeRequest = runCatching {
                 changeManagementRepository.getChangeRequest(change.id, auth)
             }.onFailure {
                 it.klogSelf(logger)
             }.getOrThrow()
-
+    
             logChangeRequestStatus(changeRequest)
-
+    
             if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
                 return this
             }
@@ -325,34 +329,34 @@ class ChangeHandler(
         }
         throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
     }
-
+    
     fun getItSystem(): ItSystem {
         require(::itSystem.isInitialized) {
             "Missing required IT system information."
         }
         return itSystem
     }
-
+    
     fun getChange(): Change {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFORMATION }
         return change
     }
-
+    
     fun comment(comment: String): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFORMATION }
         if (comment.isNotEmpty()) {
             logger.info { "Adding custom comment to change." }
             changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
         }
         return this
     }
-
+    
     fun getComments(changeId: String): List<ChangeComment> {
         return changeManagementRepository.getComments(changeId, auth)
     }
-
+    
     fun getUrl(): String {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFORMATION }
         val url = change.self
         requireNotNull(url)
         return url

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -175,5 +175,6 @@ open class SharepointClient(private val user: String, private val password: Stri
         const val ISHARE_TEST_LIST = "Pipeline%20Approvals%20TEST"
         const val ISHARE_WEBAPPLICATION_BY_ID_URL =
             "https://itm.prg-dc.dhl.com/sites/it-sec/Lists/Pipeline%20Approval%20Configuration/DispForm.aspx?ID="
+        const val ACCEPT_HEADER_VALUE = "application/json;odata=verbose"
     }
 }

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -22,11 +22,14 @@ data class LicenseBlackListEntry(
 
 object OslcComplianceChecker : KLogging() {
 
+    private const val NOT_FOUND = "not found"
+
     private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: NOT_FOUND
     private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: NOT_FOUND
+    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: NOT_FOUND
+
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -3,17 +3,21 @@ package de.deutschepost.sdm.cdlib.utils
 import java.io.File
 import java.security.MessageDigest
 
+object SHAUtils {
+    const val SHA_256 = "SHA-256"
+}
+
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHAUtils.SHA_256)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHAUtils.SHA_256)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHAUtils.SHA_256)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -79,6 +79,10 @@ class ChangeOslcIntegrationTest(
     }
 
     init {
+        companion object {
+            const val ENTRY_URL = "EntryUrl: "
+        }
+
         context("Creating oslc change is a success") {
             test("change create --oslc missing distribution") {
                 val (ret, output) = withStandardOutput {
@@ -96,7 +100,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
             }
@@ -107,7 +111,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0
@@ -119,7 +123,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcGradlePluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -78,62 +78,66 @@ class ChangeCloseIntegrationTest(
             output shouldContain "Closing change"
             output shouldNotContain "Could not transition to 'Under Review'."
             output shouldContain "Transitioning to next change request phase."
+            companion object {
+                const val PUSHING_METRIC_OBJECT = "Pushing following metric object:"
+            }
+            
             output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain PUSHING_METRIC_OBJECT
             exitCode shouldBe 0
-        }
-
-        "Close change request fails when no change was created" {
-            changeHandler
-                .findExisting()
-                .closeExisting()
-            val (exitCode, closeOutput) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                )
             }
-
-            closeOutput shouldContain "Could not find change to close for the current pipeline."
-            exitCode shouldBe -1
-        }
-
-        "Close change request fails and prints warnings when multiple changes were created" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, closeOutput) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                )
+            
+            "Close change request fails when no change was created" {
+                changeHandler
+                    .findExisting()
+                    .closeExisting()
+                val (exitCode, closeOutput) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CloseCommand::class.java,
+                        *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                    )
+                }
+            
+                closeOutput shouldContain "Could not find change to close for the current pipeline."
+                exitCode shouldBe -1
             }
-
-            closeOutput shouldContain "Found multiple changes for this pipeline, please close them manually using the links below: "
-            exitCode shouldBe -1
-        }
-
-        "Publishing metrics with invalid parameter status fails and prints warnings" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status Invalid".toArgsArray()
-                )
+            
+            "Close change request fails and prints warnings when multiple changes were created" {
+                changeHandler
+                    .post(changeDetails)
+                    .preauthorize()
+                    .transition(OPEN_TO_IMPLEMENTATION)
+                    .post(changeDetails)
+                    .preauthorize()
+                    .transition(OPEN_TO_IMPLEMENTATION)
+            
+                val (exitCode, closeOutput) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CloseCommand::class.java,
+                        *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                    )
+                }
+            
+                closeOutput shouldContain "Found multiple changes for this pipeline, please close them manually using the links below: "
+                exitCode shouldBe -1
             }
-
-            output shouldContain "Failed to parse Pipeline status"
-            output shouldNotContain "Failed to create metric object."
-            exitCode shouldBe -1
+            
+            "Publishing metrics with invalid parameter status fails and prints warnings" {
+                changeHandler
+                    .post(changeDetails)
+                    .preauthorize()
+                    .transition(OPEN_TO_IMPLEMENTATION)
+            
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CloseCommand::class.java,
+                        *"--debug --test --jira-token $token --commercial-reference $commercialReference --status Invalid".toArgsArray()
+                    )
+                }
+            
+                output shouldContain "Failed to parse Pipeline status"
+                output shouldNotContain "Failed to create metric object."
+                exitCode shouldBe -1
             changeTestHelper.closeChangeRequest(token, commercialReference)
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -63,6 +63,10 @@ class ChangeCreateCommandTest(
             output shouldContain "Missing required argument(s): --commercial-reference=<commercialReference>"
         }
 
+        companion object {
+            const val ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE = "java.lang.IllegalArgumentException"
+        }
+
         "Command fails if webapproval is requested with missing parameters." {
             val (exitCode, output) = withStandardOutput {
                 PicocliRunner.call(
@@ -71,7 +75,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
         }
 
         "Command fails if oslc but no distribution was passed" {
@@ -82,7 +86,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
         }
 
         "Command doesn't fail if no-oslc and no distribution was passed" {
@@ -93,8 +97,9 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
             output shouldContain "Verifying reports..."
+        }
         }
 
         "Parsing deployment status string returns expected enum" {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
@@ -97,7 +97,13 @@ class ChangeCreateIntegrationTest(
                     "  Determined change type --> MINOR"
                 output shouldContain "Updating change request type: MINOR"
                 output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
+                companion object {
+                    private const val CHECKING_STATUS_MESSAGE = "Checking change request status for approval every "
+                }
+                
+                ... // Other parts of the code
+                
+                output shouldContain CHECKING_STATUS_MESSAGE
                 output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
 
             }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -165,6 +165,7 @@ class ChangeManagementRepositoryTest(
             val itSystemName = "itSystemName"
             val itSystemKey = "itSystemKey"
             val criticality = "Nicht kritisch/Archiv"
+            val BUSINESS_KRITIKALITAET = "Business Kritikalität"
             val itSystemResponse = ItSystemResponse(
                 objectEntries = listOf(
                     JiraObjectEntry(
@@ -184,7 +185,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_KRITIKALITAET,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -196,11 +197,20 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_KRITIKALITAET,
                                                 6
                                             ),
                                             objectKey = "objectKey",
                                             label = "label"
+                                        ),
+                                    )
+                                ),
+                                objectTypeAttributeId = itSystemAttributeId
+                            )
+                        ),
+                    ),
+                )
+            )
                                         ),
                                     )
                                 ),

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
@@ -36,31 +36,34 @@ class NameResolverAzureTest(
         SystemEnvironmentTestListener(
             mapOf(
                 "BUILD_BUILDID" to "12657",
-                "BUILD_DEFINITIONNAME" to "ICTO-3339_SDM-phippyandfriends",
+                "BUILD_DEFINITIONNAME" to Companion.TEST_DEFINITION_NAME,
                 "BUILD_SOURCEBRANCHNAME" to "i593_test",
                 "SYSTEM_COLLECTIONURI" to "https://dev.azure.com/sw-zustellung-31b3183/",
                 "SYSTEM_TEAMPROJECT" to "ICTO-3339_SDM",
                 "TF_BUILD" to "True",
                 "SYSTEM_DEFINITIONID" to "912345",
                 "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "i593_test"
-            ),
-            OverrideMode.SetOrOverride
-        )
-    )
-
-    @BeforeAll
-    fun initMocks() {
-        mockkObject(GitRepository)
-        every { GitRepository.getRemoteUrl(any()) } returns "https://git.dhl.com/CDLib/CDLib.git"
-        every { GitRepository.lastBranchCommit(any()) } returns GitRevision(
-            id = "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
-            longMessage = "Dummy \"Commit\"",
-            shortMessage = "Dummy \$Commit",
-            authorName = "Firstname Author",
-            authorEmail = "f.a@dhl.com",
-            committerName = "Firstname Committer",
-            committerEmail = "f.c@dhl.com"
-        )
+                        ),
+                        OverrideMode.SetOrOverride
+                    )
+                
+                    @BeforeAll
+                    fun initMocks() {
+                        mockkObject(GitRepository)
+                        every { GitRepository.getRemoteUrl(any()) } returns "https://git.dhl.com/CDLib/CDLib.git"
+                        every { GitRepository.lastBranchCommit(any()) } returns GitRevision(
+                id = "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
+                longMessage = "Dummy \"Commit\"",
+                shortMessage = "Dummy \$Commit",
+                authorName = "Firstname Author",
+                authorEmail = "f.a@dhl.com",
+                committerName = "Firstname Committer",
+                committerEmail = "f.c@dhl.com"
+                        )
+                
+                    companion object {
+                        const val TEST_DEFINITION_NAME = "ICTO-3339_SDM-phippyandfriends"
+                    }
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -39,6 +39,10 @@ class NamesCommandAzureTest : AnnotationSpec() {
         )
     )
 
+    companion object {
+        private const val VSO_TASK_VARIABLE = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+    }
+
     @BeforeAll
     fun initMocks() {
         mockkObject(GitRepository)

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -18,7 +18,11 @@ class NamesCommandTest : DescribeSpec({
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            companion object {
+                const val DISPLAY_HELP_MESSAGE = "should display help"
+            }
+            
+            it(DISPLAY_HELP_MESSAGE) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -12,6 +12,9 @@ import io.mockk.mockkObject
 @Tags("UnitTest")
 class RepositoryTest : AnnotationSpec() {
     private val currDir = System.getProperty("user.dir")
+    private companion object {
+        const val EMAIL = "f.l@dhl.com"
+    }
 
     @BeforeAll
     fun initMocks() {
@@ -22,9 +25,9 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = EMAIL,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = EMAIL
         )
     }
 
@@ -35,9 +38,9 @@ class RepositoryTest : AnnotationSpec() {
         revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.authorEmail shouldBeEqualComparingTo EMAIL
         revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.committerEmail shouldBeEqualComparingTo EMAIL
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -79,7 +79,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 0"
             }
 
@@ -90,7 +90,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
             }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -41,6 +41,9 @@ class ReportOslcNPMPluginIntegrationTest(
     )
 
     init {
+        companion object {
+            const val UPLOADED_ARTIFACT_MESSAGE = "Uploaded Artifact:"
+        }
         context("Check OSLC-Plugin report and upload") {
             test("Check OSLC-Plugin report locally") {
                 val args = "--debug --files $jsonFile --no-distribution".toArgsArray()
@@ -50,7 +53,7 @@ class ReportOslcNPMPluginIntegrationTest(
                 ret shouldBeExactly 0
                 output shouldContain "Policy Profile: Non-Distribution"
             }
-
+    
             test("Upload OSLC-Plugin report to artifactory") {
                 val args =
                     "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
@@ -58,7 +61,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT_MESSAGE
             }
             // TODO: Delete after sundown
             test("Upload OSLC-Plugin report to LCM artifactory") {
@@ -68,9 +71,9 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT_MESSAGE
             }
-
+    
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
                 val args = "--debug --files $jsonFailingFile --distribution".toArgsArray()
                 val (ret, output) = withStandardOutput {
@@ -79,16 +82,15 @@ class ReportOslcNPMPluginIntegrationTest(
                 ret shouldBeExactly -1
                 output shouldContain "Policy Profile: Distribution"
             }
-
+    
             test("Trying to upload failing OSLC-Plugin report to artifactory should missing") {
-
                 val args =
                     "--debug --files $jsonFailingFile --distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
                 val (ret, output) = withStandardOutput {
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldNotContain "Uploaded Artifact:"
+                output shouldNotContain UPLOADED_ARTIFACT_MESSAGE
             }
         }
     }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -23,7 +23,8 @@ import java.io.File
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class FnciReportTest : FunSpec({
-    val projectPath = "src/test/resources/fnci/fnci-project.json"
+    private val fnciProjectPath = "src/test/resources/fnci/fnci-project.json"
+    val projectPath = fnciProjectPath
     val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
     context("Project Info") {
         test("Parses projectInfo correctly") {
@@ -52,7 +53,7 @@ class FnciReportTest : FunSpec({
         val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
         test("Generate OslcTestResult") {
             val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
+                OslcTestResult.from(FnciTestResult(projectInfo, inventory), fnciProjectPath)
             report.complianceStatus shouldBe OslcComplianceStatus.RED
             report.unapprovedItems.shouldNotBeEmpty()
             defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
@@ -61,7 +62,7 @@ class FnciReportTest : FunSpec({
         test("Only approved is compliant") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                fnciProjectPath
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()
@@ -71,9 +72,11 @@ class FnciReportTest : FunSpec({
         test("Canonical file name should depend on project, not files") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                fnciProjectPath
             )
             report.canonicalFilename shouldEndWith "${report.projectName}.json"
         }
+    }
+})
     }
 })

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -43,10 +43,14 @@ class OslcComplianceAcceptedListTest : FunSpec() {
 
     init {
         context("de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.VersionSpecification parsing") {
+            companion object {
+                const val INPUT_STRING_HEADER = "Input String"
+            }
+            
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
+                        headers(INPUT_STRING_HEADER, "Default Value", "Expected"),
                         row("0.0.0", 0, VersionSpecification(0, 0, 0)),
                         row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
                         row("1.2.3", 0, VersionSpecification(1, 2, 3)),
@@ -58,11 +62,14 @@ class OslcComplianceAcceptedListTest : FunSpec() {
                     VersionSpecification.fromString(input, default) shouldBe expected
                 }
             }
-
+            
+            
+            
+            
             test("Testing invalid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value"),
+                        headers(INPUT_STRING_HEADER, "Default Value"),
                         row("a.b.c", 0),
                         row("error", 0),
                         row("3,2,5", 0),
@@ -71,11 +78,13 @@ class OslcComplianceAcceptedListTest : FunSpec() {
                     shouldThrow<NumberFormatException> { VersionSpecification.fromString(input, default) }
                 }
             }
-
+            
+            
+            
             test("Testing valid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
+                        headers(INPUT_STRING_HEADER, "ExpectedMin", "ExpectedMax"),
                         row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
                         row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
                         row(
@@ -100,11 +109,13 @@ class OslcComplianceAcceptedListTest : FunSpec() {
                     VersionSpecification.rangeFromString(input) shouldBe min..max
                 }
             }
-
+            
+            
+            
             test("Testing invalid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String"),
+                        headers(INPUT_STRING_HEADER),
                         row("1.2.3-11.12.13-1.2.3"),
                         row("1-1-1"),
                     )

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
@@ -38,7 +38,10 @@ class OslcComplianceCheckerTest : FunSpec() {
             )
         )
     )
-    private val licenseMozillaName = "Mozilla Public License 2.0"
+    companion object {
+        const val MOZILLA_PUBLIC_LICENSE_20 = "Mozilla Public License 2.0"
+    }
+    private val licenseMozillaName = MOZILLA_PUBLIC_LICENSE_20
     private val depWithCDDL = OslcDependencyLicenseEntry(
         dependencyName = "test.should.fail:cddl",
         dependencyVersion = "",
@@ -181,7 +184,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     "GNU Lesser General Public License 2.1" to 9,
                     "GNU General Public License 2.0" to 4,
                     "GNU General Public License 3.0" to 4,
-                    "Mozilla Public License 2.0" to 5
+                    MOZILLA_PUBLIC_LICENSE_20 to 5
                 )
                 val notExpectedLicenses = listOf(
                     "Apache License 2.0",
@@ -235,7 +238,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     "GNU Lesser General Public License 2.1",
                     "GNU General Public License 2.0",
                     "GNU General Public License 3.0",
-                    "Mozilla Public License 2.0"
+                    MOZILLA_PUBLIC_LICENSE_20
                 )
                 printDefinitions(definitions)
                 expectedLicenses.forEach { (license: String, numberOfAliases: Int) ->
@@ -282,7 +285,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                 val epl2 = output.entries.firstOrNull { it.key.license == "Eclipse Public License 2.0" }
                 epl2 shouldNotBe null
                 epl2?.value?.size shouldBe 1
-                val mpl2 = output.entries.firstOrNull { it.key.license == "Mozilla Public License 2.0" }
+                val mpl2 = output.entries.firstOrNull { it.key.license == MOZILLA_PUBLIC_LICENSE_20 }
                 mpl2 shouldNotBe null
                 mpl2?.value?.size shouldBe 1
                 val unknown = output.entries.firstOrNull { it.key.license == "UNKNOWN" }


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
