### PR TITLE
Sonar: Do not hardcode version numbers. (rule kotlin:S6624)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -55,7 +55,8 @@ dependencies {
     implementation("org.apache.httpcomponents:httpclient:$httpClientVersion")
     implementation("org.codelibs:jcifs:$jcifsVersion")
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
-    implementation("com.azure:azure-identity")
+    val azureIdentityVersion = "1.0.0"
+    implementation("com.azure:azure-identity:", azureIdentityVersion)
     implementation("net.minidev:json-smart:2.5.2")
     implementation("com.azure:azure-cosmos")
     

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -51,8 +51,8 @@ dependencies {
     // logging
     val kotlinLoggingVersion = "2.1.23"
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
-    // webapproval sharepoint
-    implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    val httpClientVersion = "4.5.14"
+    implementation("org.apache.httpcomponents:httpclient:$httpClientVersion")
     implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
     // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -49,7 +49,8 @@ dependencies {
     val artifactoryJavaClientVersion = "2.19.1"
     implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryJavaClientVersion}")
     // logging
-    implementation("io.github.microutils:kotlin-logging:2.1.23")
+    val kotlinLoggingVersion = "2.1.23"
+    implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     // webapproval sharepoint
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
     implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -28,13 +28,15 @@ val kotlinCoroutines = project.properties["kotlinCoroutines"] as String
 
 dependencies {
     ksp("info.picocli:picocli-codegen")
+    val jcifsVersion = "1.3.18.3"
+    
     implementation("org.yaml:snakeyaml")
     implementation("info.picocli:picocli")
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut.kotlin:micronaut-kotlin-runtime")
     implementation("io.micronaut.picocli:micronaut-picocli")
     implementation("io.micronaut:micronaut-retry")
-    implementation("javax.annotation:javax.annotation-api") // todo remove?
+    implementation("javax.annotation:javax.annotation-api")
     implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${kotlinCoroutines}")
@@ -44,24 +46,19 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
-
-    // artifactory
+    
     val artifactoryJavaClientVersion = "2.19.1"
     implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryJavaClientVersion}")
-    // logging
     val kotlinLoggingVersion = "2.1.23"
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     val httpClientVersion = "4.5.14"
     implementation("org.apache.httpcomponents:httpclient:$httpClientVersion")
-    implementation("org.codelibs:jcifs:1.3.18.3") // Never update this, Version 2 is incompatible
-    // JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)
+    implementation("org.codelibs:jcifs:$jcifsVersion")
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
-    //publish metrics to azure cosmosdb
     implementation("com.azure:azure-identity")
-    implementation("net.minidev:json-smart:2.5.2") // override bc vuln
+    implementation("net.minidev:json-smart:2.5.2")
     implementation("com.azure:azure-cosmos")
-
-    // Tests only
+    
     testImplementation("io.mockk:mockk")
     testImplementation("io.kotest:kotest-extensions-now")
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -48,16 +48,19 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     
     val artifactoryJavaClientVersion = "2.19.1"
-    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryJavaClientVersion}")
     val kotlinLoggingVersion = "2.1.23"
-    implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     val httpClientVersion = "4.5.14"
+    val azureIdentityVersion = "1.0.0"
+    val eclipseJgitVersion = "7.1.0.202411261347-r"
+    val jsonSmartVersion = "2.5.2"
+    
+    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryJavaClientVersion}")
+    implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     implementation("org.apache.httpcomponents:httpclient:$httpClientVersion")
     implementation("org.codelibs:jcifs:$jcifsVersion")
-    implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
-    val azureIdentityVersion = "1.0.0"
-    implementation("com.azure:azure-identity:", azureIdentityVersion)
-    implementation("net.minidev:json-smart:2.5.2")
+    implementation("org.eclipse.jgit:org.eclipse.jgit:${eclipseJgitVersion}")
+    implementation("com.azure:azure-identity:${azureIdentityVersion}")
+    implementation("net.minidev:json-smart:${jsonSmartVersion}")
     implementation("com.azure:azure-cosmos")
     
     testImplementation("io.mockk:mockk")

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -46,7 +46,8 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     // artifactory
-    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:2.19.1")
+    val artifactoryJavaClientVersion = "2.19.1"
+    implementation("org.jfrog.artifactory.client:artifactory-java-client-services:${artifactoryJavaClientVersion}")
     // logging
     implementation("io.github.microutils:kotlin-logging:2.1.23")
     // webapproval sharepoint


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>There are several ways to fix it:</p>
<ul>
  <li> extract the versions in variables </li>
  <li> use Spring dependency management plugin: <code>io.spring.dependency-management</code> </li>
  <li> use centralized dependencies with <a
  href="https://www.youtube.com/watch?v=WvtcCCCLfOc&amp;list=PL0UJI1nZ56yAHv9H9kZA6vat4N1kSRGis&amp;index=21">Version Catalogs</a> </li>
</ul>

<h4>Noncompliant code example</h4>
<pre data-diff-id="1" data-diff-type="noncompliant">
dependencies {
    testImplementation("org.mockito:mockito-core:4.5.1")
    testImplementation("org.mockito:mockito-inline:4.5.1")
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
const val mockitoVersion = "4.5.1"

dependencies {
    testImplementation("org.mockito:mockito-core:$mockitoVersion")
    testImplementation("org.mockito:mockito-inline:$mockitoVersion")
}
</pre>
<p>Alternatively, you can put <code>const val mockitoVersion = "4.5.1"</code> in any <code>.kt</code> file in <code>buildSrc/src/main/kotlin</code> or
use a more robust dependency management mechanism like <a href="https://plugins.gradle.org/plugin/io.spring.dependency-management">Spring dependency
management plugin</a> or <a href="https://www.youtube.com/watch?v=WvtcCCCLfOc&amp;list=PL0UJI1nZ56yAHv9H9kZA6vat4N1kSRGis&amp;index=21">Version
Catalogs</a>.</p>
<p>In general hard-coded values is a well known bad practice that affects maintainability. In dependency management, this issue is even more critical
because there is the risk of accidentally having different versions for the same dependency in your configuration.</p>
<p>Keeping hard-coded dependency versions increases the cost of maintainability and complicates the update process.</p>

### These files were changed in the pull request:
#### build.gradle.kts
