### PR TITLE
Sonar: Merge this "if" statement with the nested one. (rule kotlin:S1066)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/ChangeCommand.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/ChangeCommand.kt
@@ -767,11 +767,10 @@ class ChangeCommand : SubcommandWithHelp() {
                 Labels.CHANGE_OSLC
             )
 
-            if (labels.any { label -> label in artifactoryRequiredLabels }) {
-                if (immutableRepoName.isEmpty() || artifactoryIdentityToken.isEmpty()) {
-                    logger.error { "The change for this pipeline has at least one of the following labels: webapproval, oslc. Therefore it is mandatory to supply the parameters: --artifactory-identity-token and --immutable-repo-name" }
-                    return -1
-                }
+            if (labels.any { label -> label in artifactoryRequiredLabels } && (immutableRepoName.isEmpty() || artifactoryIdentityToken.isEmpty())) {
+                logger.error { "The change for this pipeline has at least one of the following labels: webapproval, oslc. Therefore it is mandatory to supply the parameters: --artifactory-identity-token and --immutable-repo-name" }
+                return -1
+            }
             }
 
             if (status.value != "SUCCESS") {

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/OslcTestResult.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/OslcTestResult.kt
@@ -104,10 +104,8 @@ fun List<OslcTestResult>.oslcTestsVerify(appName: String, isDistribution: Boolea
         ) {
             issues.add("We have found one or multiple licenses that are not allowed by default. After talking to legal, you might be permitted to mark them as accepted according to this tutorial: https://lcm.deutschepost.de/confluence1/display/SDM/Open+Source+License+Compliance+Scan")
         }
-        if (test.policyProfile != OslcTestResult.PROFILE_PLUGIN) {
-            if (isDistribution != (!test.policyProfile.startsWith(OslcTestResult.PROFILE_NON_DISTRIBUTION))) {
-                issues.add("$appName has policy profile $isDistribution but TestResult has ${test.policyProfile}!")
-            }
+        if (test.policyProfile != OslcTestResult.PROFILE_PLUGIN && isDistribution != (!test.policyProfile.startsWith(OslcTestResult.PROFILE_NON_DISTRIBUTION))) {
+            issues.add("$appName has policy profile $isDistribution but TestResult has ${test.policyProfile}!")
         }
     }
     check(issues.isEmpty()) {


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>If merging the conditions seems to result in a more complex code, extracting the condition or part of it in a named function or variable is a
better approach to fix readability.</p>

<h4>Noncompliant code example</h4>
<pre>
if (file != null) {
  if (file.isFile() || file.isDirectory()) {  // Noncompliant
    /* ... */
  }
}
</pre>
<h4>Compliant solution</h4>
<pre>
if (file != null &amp;&amp; isFileOrDirectory(file)) {   // Compliant
  /* ... */
}
fun isFileOrDirectory(file: File): Boolean {
    return file.isFile() || file.isDirectory();
}
</pre>
<p>Nested code - blocks of code inside blocks of code - is eventually necessary, but increases complexity. This is why keeping the code as flat as
possible, by avoiding unnecessary nesting, is considered a good practice.</p>
<p>Merging <code>if</code> statements when possible will decrease the nesting of the code and improve its readability.</p>
<p>Code like</p>
<pre>
if (condition1) {
  if (condition2) {             // Noncompliant
    /* ... */
  }
}
</pre>
<p>Will be more readable as</p>
<pre>
if (condition1 &amp;&amp; condition2) { // Compliant
  /* ... */
}
</pre>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/OslcTestResult.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/ChangeCommand.kt
