### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -247,8 +247,13 @@ class ChangeHandler(
         return this
     }
 
+    companion object {
+        const val MISSING_CHANGE_INFO_MESSAGE = "Missing required change information."
+        const val MISSING_AUTH_TOKEN_MESSAGE = "Missing required authentication token."
+    }
+
     fun preauthorize(): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO_MESSAGE }
         logger.info { "Determining whether change can be preauthorized." }
         val changeType = determineChangeType()
         logTypeResults(changeType)
@@ -264,8 +269,8 @@ class ChangeHandler(
     }
 
     fun resume(): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::auth.isInitialized) { MISSING_AUTH_TOKEN_MESSAGE }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO_MESSAGE }
 
         logger.info { "Resuming change: ${change.self}" }
         logger.info { "Adding resume comment to change..." }

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -41,7 +41,7 @@ open class SharepointClient(private val user: String, private val password: Stri
 
     private fun getDigest(): String? {
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/contextinfo").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", APPLICATION_JSON_VERBOSE)
         }
         return client.execute(httpPost).use { response ->
             logger.info { "Getting Sharepoint Digest: ${response.statusLine}" }
@@ -74,7 +74,7 @@ open class SharepointClient(private val user: String, private val password: Stri
                 """
                 Failed to get digest for Record.
                 This is eiter a connection issue or a credentials issue. You can check this with following command:
-                curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: application/json;odata=verbose\"""".trimIndent()
+                curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: application/json;odata=verbose\""".trimIndent()
             }
 
         val webapprovalWithoutURL =
@@ -86,9 +86,9 @@ open class SharepointClient(private val user: String, private val password: Stri
             text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
         }.build()
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", APPLICATION_JSON_VERBOSE)
             addHeader("X-RequestDigest", digest)
-            addHeader("Content-Type", "application/json;odata=verbose")
+            addHeader("Content-Type", APPLICATION_JSON_VERBOSE)
             entity = httpEntity
         }
 
@@ -157,7 +157,7 @@ open class SharepointClient(private val user: String, private val password: Stri
     private fun getSharepointApprovalConfigurations(): SharepointApprovalConfigurations {
         val httpGet =
             HttpGet("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approval%20Configuration')/items").apply {
-                addHeader("Accept", "application/json;odata=verbose")
+                addHeader("Accept", APPLICATION_JSON_VERBOSE)
             }
         client.execute(httpGet).use { response ->
             logger.info { "Executed request ${httpGet.requestLine} --- ${response.statusLine}" }

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -22,11 +22,13 @@ data class LicenseBlackListEntry(
 
 object OslcComplianceChecker : KLogging() {
 
+    private const val NOT_FOUND = "not found"
+
     private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: NOT_FOUND
     private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: NOT_FOUND
+    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: NOT_FOUND
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -3,17 +3,23 @@ package de.deutschepost.sdm.cdlib.utils
 import java.io.File
 import java.security.MessageDigest
 
-fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
-    .digest(this.toByteArray())
-    .fold("") { str, it -> str + "%02x".format(it) }
+class HashUtils {
+    companion object {
+        const val SHA_256_ALGORITHM = "SHA-256"
+    }
 
-fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
-    .digest(this.readBytes())
-    .fold("") { str, it -> str + "%02x".format(it) }
+    fun String.sha256sum(): String = MessageDigest
+        .getInstance(SHA_256_ALGORITHM)
+        .digest(this.toByteArray())
+        .fold("") { str, it -> str + "%02x".format(it) }
 
-fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
-    .digest(this)
-    .fold("") { str, it -> str + "%02x".format(it) }
+    fun File.sha256sum(): String = MessageDigest
+        .getInstance(SHA_256_ALGORITHM)
+        .digest(this.readBytes())
+        .fold("") { str, it -> str + "%02x".format(it) }
+
+    fun ByteArray.sha256sum(): String = MessageDigest
+        .getInstance(SHA_256_ALGORITHM)
+        .digest(this)
+        .fold("") { str, it -> str + "%02x".format(it) }
+}

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -79,6 +79,7 @@ class ChangeOslcIntegrationTest(
     }
 
     init {
+        private val ENTRY_URL_LABEL = "EntryUrl: "
         context("Creating oslc change is a success") {
             test("change create --oslc missing distribution") {
                 val (ret, output) = withStandardOutput {
@@ -96,7 +97,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL_LABEL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
             }
@@ -107,7 +108,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL_LABEL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0
@@ -119,10 +120,11 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcGradlePluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL_LABEL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0
+
             }
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -204,99 +204,103 @@ class ChangeCloseIntegrationTest(
                     )
                 }
 
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
-            withEnvironment(
-                "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
-                    )
+                companion object {
+                    const val DASHBOARD_STATUS_CODE = "Dashboard status code: 201"
                 }
-
+                
                 output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                output shouldContain "INFRA"
+                output shouldContain DASHBOARD_STATUS_CODE
                 exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via AzureDevOps" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
-                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
                 }
-
-                output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully when having a fuzzy matching job url" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-            }
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
-                    "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-
-                val (exitCode, output) = withStandardOutput {
+                }
+                
+                "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
+                withEnvironment(
+                    "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                    OverrideMode.SetOrOverride
+                ) {
                     changeHandler
                         .post(changeDetails)
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
+                
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
+                        )
+                    }
+                
+                    output shouldContain "http://integration-test-url.jenkuns.example.com"
+                    output shouldContain DASHBOARD_STATUS_CODE
+                    output shouldContain "INFRA"
+                    exitCode shouldBeExactly 0
                 }
-
-                output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
-                output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
-                output shouldContain "Dashboard status code: 201"
+                }
+                
+                "Closing change successfully publishes metrics via AzureDevOps" {
+                val rnd = UUID.randomUUID().toString().substringBefore("-")
+                
+                withEnvironment(
+                    mapOf(
+                        "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
+                        "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
+                    ),
+                    OverrideMode.SetOrOverride
+                ) {
+                    changeHandler
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+                
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                        )
+                    }
+                
+                    output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
+                    output shouldContain DASHBOARD_STATUS_CODE
+                    exitCode shouldBeExactly 0
+                }
+                }
+                
+                "Closing change successfully when having a fuzzy matching job url" {
+                val rnd = UUID.randomUUID().toString().substringBefore("-")
+                
+                withEnvironment(
+                    "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
+                    OverrideMode.SetOrOverride
+                ) {
+                    changeHandler
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+                }
+                
+                withEnvironment(
+                    mapOf(
+                        "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
+                        "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
+                    ),
+                    OverrideMode.SetOrOverride
+                ) {
+                
+                    val (exitCode, output) = withStandardOutput {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                        )
+                    }
+                
+                    output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
+                    output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
+                    output shouldContain DASHBOARD_STATUS_CODE
                 exitCode shouldBeExactly 0
             }
         }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -58,6 +58,8 @@ class ChangeCloseIntegrationTest(
     )
 
     init {
+        companion object { const val METRIC_OBJECT_MESSAGE = "Pushing following metric object:" }
+
         "Closing change with commercial reference is a success" {
             changeHandler
                 .post(changeDetails)
@@ -79,7 +81,7 @@ class ChangeCloseIntegrationTest(
             output shouldNotContain "Could not transition to 'Under Review'."
             output shouldContain "Transitioning to next change request phase."
             output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain METRIC_OBJECT_MESSAGE
             exitCode shouldBe 0
         }
 
@@ -152,7 +154,7 @@ class ChangeCloseIntegrationTest(
 
             output shouldNotContain "Failed to parse Pipeline status"
             output shouldNotContain "Failed to create metric object."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain METRIC_OBJECT_MESSAGE
             exitCode shouldBe 0
         }
 
@@ -170,7 +172,13 @@ class ChangeCloseIntegrationTest(
                 }
                 output shouldNotContain "Closing change"
                 output shouldContain "not closing change request."
-                output shouldContain "Pushing following metric object:"
+                output shouldContain METRIC_OBJECT_MESSAGE
+
+
+                changeHandler.findExisting().closeExisting()
+                Thread.sleep(15.toDuration(DurationUnit.SECONDS).inWholeMilliseconds)
+            }
+        }
                 exitCode shouldBe 0
 
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -71,30 +71,42 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
-        }
-
-        "Command fails if oslc but no distribution was passed" {
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CreateCommand::class.java,
-                    *"--jira-token $token --debug --commercial-reference 5296 --test".toArgsArray()
-                )
+            companion object {
+                const val ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE = "java.lang.IllegalArgumentException"
             }
-            exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
-        }
-
-        "Command doesn't fail if no-oslc and no distribution was passed" {
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CreateCommand::class.java,
-                    *"--jira-token $token --debug --commercial-reference 5296 --test --no-oslc".toArgsArray()
-                )
+            
+            "Command fails if webapproval is requested with missing parameters." {
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CreateCommand::class.java,
+                        *"--jira-token $token --debug --commercial-reference 5296 --test --webapproval --no-distribution".toArgsArray()
+                    )
+                }
+                exitCode shouldBeExactly -1
+                output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
             }
-            exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
-            output shouldContain "Verifying reports..."
+            
+            "Command fails if oslc but no distribution was passed" {
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CreateCommand::class.java,
+                        *"--jira-token $token --debug --commercial-reference 5296 --test".toArgsArray()
+                    )
+                }
+                exitCode shouldBeExactly -1
+                output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
+            }
+            
+            "Command doesn't fail if no-oslc and no distribution was passed" {
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CreateCommand::class.java,
+                        *"--jira-token $token --debug --commercial-reference 5296 --test --no-oslc".toArgsArray()
+                    )
+                }
+                exitCode shouldBeExactly -1
+                output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE
+                output shouldContain "Verifying reports..."
         }
 
         "Parsing deployment status string returns expected enum" {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
@@ -97,10 +97,12 @@ class ChangeCreateIntegrationTest(
                     "  Determined change type --> MINOR"
                 output shouldContain "Updating change request type: MINOR"
                 output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
-
-            }
+                const val CHECKING_CHANGE_REQUEST_STATUS_MSG = "Checking change request status for approval every "
+                
+                                output shouldContain CHECKING_CHANGE_REQUEST_STATUS_MSG
+                                output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
+                
+                            }
             changeTestHelper.closeChangeRequest(
                 token,
                 commercialReference

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -165,6 +165,8 @@ class ChangeManagementRepositoryTest(
             val itSystemName = "itSystemName"
             val itSystemKey = "itSystemKey"
             val criticality = "Nicht kritisch/Archiv"
+            private const val BUSINESS_CRITICALITY = "Business Kritikalität"
+            
             val itSystemResponse = ItSystemResponse(
                 objectEntries = listOf(
                     JiraObjectEntry(
@@ -184,7 +186,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_CRITICALITY,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -196,12 +198,16 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_CRITICALITY,
                                                 6
                                             ),
                                             objectKey = "objectKey",
                                             label = "label"
                                         ),
+                                    )
+                                ),
+                                objectTypeAttributeId = itSystemAttributeId
+                            )
                                     )
                                 ),
                                 objectTypeAttributeId = itSystemAttributeId

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
@@ -31,12 +31,15 @@ class NameResolverAzureTest(
 ) : AnnotationSpec() {
     private val before = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toInstant()
 
+    companion object {
+        const val ICTO_3339_SDM_PHIPPY_AND_FRIENDS = "ICTO-3339_SDM-phippyandfriends"
+    }
 
     override fun listeners() = listOf(
         SystemEnvironmentTestListener(
             mapOf(
                 "BUILD_BUILDID" to "12657",
-                "BUILD_DEFINITIONNAME" to "ICTO-3339_SDM-phippyandfriends",
+                "BUILD_DEFINITIONNAME" to ICTO_3339_SDM_PHIPPY_AND_FRIENDS,
                 "BUILD_SOURCEBRANCHNAME" to "i593_test",
                 "SYSTEM_COLLECTIONURI" to "https://dev.azure.com/sw-zustellung-31b3183/",
                 "SYSTEM_TEAMPROJECT" to "ICTO-3339_SDM",
@@ -87,7 +90,7 @@ class NameResolverAzureTest(
         }
         withEnvironment(
             mapOf(
-                "BUILD_DEFINITIONNAME" to "ICTO-3339_SDM-phippyandfriends-very-long-app-name-that-needs-to-be-truncated",
+                "BUILD_DEFINITIONNAME" to "${NameResolverAzureTest.ICTO_3339_SDM_PHIPPY_AND_FRIENDS}-very-long-app-name-that-needs-to-be-truncated",
                 "BUILD_SOURCEBRANCHNAME" to "renovate/this-is-a-very-long-branch-name-that-needs-to-be-truncated",
                 "CDLIB_EFFECTIVE_BRANCH_NAME" to "renovate/this-is-a-very-long-branch-name-that-needs-to-be-truncated"
             ), OverrideMode.SetOrOverride
@@ -100,7 +103,7 @@ class NameResolverAzureTest(
 
     @Test
     fun testCreate_APP_NAME() {
-        resolver[Names.CDLIB_APP_NAME] shouldBeEqualComparingTo "ICTO-3339_SDM-phippyandfriends"
+        resolver[Names.CDLIB_APP_NAME] shouldBeEqualComparingTo NameResolverAzureTest.ICTO_3339_SDM_PHIPPY_AND_FRIENDS
     }
 
     @Test
@@ -136,7 +139,7 @@ class NameResolverAzureTest(
 
     @Test
     fun testCreate_JOB_URL() {
-        resolver[Names.CDLIB_JOB_URL] shouldContainIgnoringCase "https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM/_build/results?buildId=12657"
+        resolver[Names.CDLIB_JOB_URL] shouldContainIgnoringCase "https://dev.azure.com/sw-zustellung-31b3183/${NameResolverAzureTest.ICTO_3339_SDM_PHIPPY_AND_FRIENDS}/_build/results?buildId=12657"
     }
 
     @Test
@@ -184,7 +187,8 @@ class NameResolverAzureTest(
     @Test
     fun testCreate_RELEASE_NAME() {
         resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "_12657_a5c5bc3"
-        resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "ICTO-3339_SDM-phippyandfriends"
+        resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase NameResolverAzureTest.ICTO_3339_SDM_PHIPPY_AND_FRIENDS
+    }
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -61,7 +61,11 @@ class NamesCommandAzureTest : AnnotationSpec() {
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
 
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        companion object {
+            const val CDLIB_APP_NAME_VAR = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        }
+
+        output shouldContainIgnoringCase CDLIB_APP_NAME_VAR
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
@@ -85,7 +89,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             val args = "names create --from-release-name $releaseName".toArgsArray()
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase CDLIB_APP_NAME_VAR
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_VERSION;isOutput=true]20211203.1809.18"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_BUILD_NUMBER;isOutput=true]20210908.16"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
@@ -118,7 +122,8 @@ class NamesCommandAzureTest : AnnotationSpec() {
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+            output shouldContainIgnoringCase CDLIB_APP_NAME_VAR
+
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -12,13 +12,16 @@ import withStandardOutput
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class NamesCommandTest : DescribeSpec({
+    companion object {
+        const val DISPLAY_HELP_MESSAGE = "should display help"
+    }
     describe("cdlib names") {
         describe("names -h") {
             val (_, output) = withStandardOutput {
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(DISPLAY_HELP_MESSAGE) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -13,6 +13,10 @@ import io.mockk.mockkObject
 class RepositoryTest : AnnotationSpec() {
     private val currDir = System.getProperty("user.dir")
 
+    companion object {
+        const val EMAIL_ADDRESS = "f.l@dhl.com"
+    }
+
     @BeforeAll
     fun initMocks() {
         mockkObject(GitRepository)
@@ -22,9 +26,9 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = EMAIL_ADDRESS,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = EMAIL_ADDRESS
         )
     }
 
@@ -35,9 +39,9 @@ class RepositoryTest : AnnotationSpec() {
         revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.authorEmail shouldBeEqualComparingTo EMAIL_ADDRESS
         revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.committerEmail shouldBeEqualComparingTo EMAIL_ADDRESS
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -42,6 +42,9 @@ class ReportOslcGradlePluginIntegrationTest(
     )
 
     init {
+        companion object {
+            const val POLICY_PROFILE_DISTRIBUTION = "Policy Profile: Distribution"
+        }
         context("Check OSLC-Plugin report and upload") {
             test("Check OSLC-Plugin report locally") {
                 val args = "--debug --files $jsonFile --no-distribution".toArgsArray()
@@ -51,7 +54,7 @@ class ReportOslcGradlePluginIntegrationTest(
                 ret shouldBeExactly 0
                 output shouldContain "Policy Profile: Non-Distribution"
             }
-
+    
             test("Upload OSLC-Plugin report to artifactory") {
                 val args =
                     "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
@@ -61,17 +64,17 @@ class ReportOslcGradlePluginIntegrationTest(
                 ret shouldBeExactly 0
                 output shouldContain "Uploaded Artifact:"
             }
-
+    
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
                 val args = "--debug --files $jsonFile --distribution".toArgsArray()
                 val (ret, output) = withStandardOutput {
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldNotContain "Unapproved Licenses Count: 0"
             }
-
+    
             test("Check OSLC-Plugin report locally should succeed with accepted list") {
                 val args =
                     "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFile".toArgsArray()
@@ -79,10 +82,10 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 0"
             }
-
+    
             test("Check OSLC-Plugin report locally should fail with accepted list because of wrong license") {
                 val args =
                     "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongLicense".toArgsArray()
@@ -90,11 +93,11 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
             }
-
+    
             test("Check OSLC-Plugin report locally should fail with accepted list because of wrong version number") {
                 val args =
                     "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongVersion".toArgsArray()
@@ -102,10 +105,12 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
             }
+    
+    
 
             test("Trying to upload failing OSLC-Plugin report to artifactory should missing") {
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -50,7 +50,7 @@ class ReportOslcNPMPluginIntegrationTest(
                 ret shouldBeExactly 0
                 output shouldContain "Policy Profile: Non-Distribution"
             }
-
+    
             test("Upload OSLC-Plugin report to artifactory") {
                 val args =
                     "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
@@ -58,7 +58,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOAD_ARTIFACT_MESSAGE
             }
             // TODO: Delete after sundown
             test("Upload OSLC-Plugin report to LCM artifactory") {
@@ -68,9 +68,9 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOAD_ARTIFACT_MESSAGE
             }
-
+    
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
                 val args = "--debug --files $jsonFailingFile --distribution".toArgsArray()
                 val (ret, output) = withStandardOutput {
@@ -79,17 +79,19 @@ class ReportOslcNPMPluginIntegrationTest(
                 ret shouldBeExactly -1
                 output shouldContain "Policy Profile: Distribution"
             }
-
+    
             test("Trying to upload failing OSLC-Plugin report to artifactory should missing") {
-
+    
                 val args =
                     "--debug --files $jsonFailingFile --distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
                 val (ret, output) = withStandardOutput {
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldNotContain "Uploaded Artifact:"
+                output shouldNotContain UPLOAD_ARTIFACT_MESSAGE
             }
+        }
+    }
         }
     }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -26,6 +26,8 @@ import java.io.File
 @Tags("UnitTest")
 class OslcComplianceAcceptedListTest : FunSpec() {
 
+    private val INPUT_STRING_HEADER = "Input String"
+
     private val acceptedListFileWrongLicense = File("src/test/resources/oslc/acceptedList-wrongLicense.json")
     private val acceptedListFileWrongVersion = File("src/test/resources/oslc/acceptedList-wrongVersion.json")
 
@@ -46,7 +48,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
+                        headers(INPUT_STRING_HEADER, "Default Value", "Expected"),
                         row("0.0.0", 0, VersionSpecification(0, 0, 0)),
                         row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
                         row("1.2.3", 0, VersionSpecification(1, 2, 3)),
@@ -62,7 +64,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing invalid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value"),
+                        headers(INPUT_STRING_HEADER, "Default Value"),
                         row("a.b.c", 0),
                         row("error", 0),
                         row("3,2,5", 0),
@@ -75,7 +77,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
+                        headers(INPUT_STRING_HEADER, "ExpectedMin", "ExpectedMax"),
                         row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
                         row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
                         row(
@@ -104,7 +106,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing invalid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String"),
+                        headers(INPUT_STRING_HEADER),
                         row("1.2.3-11.12.13-1.2.3"),
                         row("1-1-1"),
                     )

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
@@ -86,7 +86,9 @@ class OslcComplianceCheckerTest : FunSpec() {
                 url = "https://openjdk.java.net/legal/gplv2+ce.html",
             )
         )
+    
     )
+    private const val MOZILLA_PUBLIC_LICENSE_20 = "Mozilla Public License 2.0"
     private val licenseCPLCEName = "GNU GPL with Classpath/Linking Exception"
     private val depWithAPL2 = OslcDependencyLicenseEntry(
         dependencyName = "test.should.succeed:APL",


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
