### PR TITLE
Sonar: Remove this it parameter declaration or give this lambda parameter a meaningful name. (rule kotlin:S6558)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/external/OslcMavenPluginTestResult.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/external/OslcMavenPluginTestResult.kt
@@ -41,8 +41,8 @@ fun OslcTestResult.Companion.from(
         policyProfile = PROFILE_PLUGIN,
         unapprovedItems = oslcMavenPluginTestResult.incompliantLicenses.groupBy { license ->
             license.license
-        }.mapValues { it ->
-            mapOf("REJECTED" to it.value.map { it.license })
+        }.mapValues {
+                    mapOf("REJECTED" to it.value.map { it.license })
         },
         totalArtifactCount = oslcMavenPluginTestResult.licenses.sumOf { it.count },
         complianceStatus = when (oslcMavenPluginTestResult.complianceStatus) {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderAzureTest.kt
@@ -52,7 +52,7 @@ class NameProviderAzureTest(platformProvider: DefaultNameProviderFactory) : Anno
 
     @Test
     fun testProvide_Size() {
-        val entries = result.split("\n").filter { it -> it.isNotBlank() }
+        val entries = result.split("\n").filter { it.isNotBlank() }
         entries.size shouldBeExactly Names.values().size
     }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderJenkinsTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderJenkinsTest.kt
@@ -54,7 +54,7 @@ class NameProviderJenkinsTest(platformProvider: DefaultNameProviderFactory) : An
 
     @Test
     fun testProvide_Size() {
-        val entries = result.split("\n").filter { it -> it.isNotBlank() }
+        val entries = result.split("\n").filter { it.isNotBlank() }
         entries.size shouldBeExactly Names.values().size
     }
 


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>Lambda expressions are a concise way of writing anonymous functions. Many lambda expressions have only one parameter, when this is true the
compiler can determine the parameter type by context. Thus when using <code>it</code> with single parameter lambda expressions, you do not need to
declare the type.</p>

<h4>Noncompliant code example</h4>
<p>This lambda expression uses a single parameter so we do not need to explicitly declare the <code>it</code> parameter.</p>
<pre>
listOf(1, 2, 3).forEach { it -&gt; it.and(6) } // Noncompliant
</pre>
<h4>Compliant solution</h4>
<p>Instead, we can write this lambda expression without using <code>→</code> because the compiler assumes that you want to use the implicit
<code>it</code> parameter to refer to the current element being iterated over.</p>
<pre>
listOf(1, 2, 3).forEach { it.and(6) } // Compliant
</pre>
<h4>Noncompliant code example</h4>
<pre>
val l1: (Int) -&gt; Int = { it -&gt; it + 5 } // Noncompliant
</pre>
<h4>Compliant solution</h4>
<p>In the first example, since since the expression to the left of the arrow is a lambda parameter declaration it, 'it' should be removed. In the
second example, you must use the lambda parameter to be able to declare the parameter type because it can not be inferred from the context.</p>
<pre>
val l3: (Int) -&gt; Int = { it + 5 } // Compliant
val l3 = {it: Int -&gt; it + 5 } // Compliant, need to know the type
</pre>
<p><code>it</code> is a special identifier that allows you to refer to the current parameter being passed to a lambda expression without explicitly
naming the parameter.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/external/OslcMavenPluginTestResult.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderJenkinsTest.kt
