### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -334,25 +334,28 @@ class ChangeHandler(
     }
 
     fun getChange(): Change {
-        require(::change.isInitialized) { "Missing required change information." }
+        companion object { const val MISSING_CHANGE_INFO_MESSAGE = "Missing required change information." }
+        
+        fun getChange(): Change {
+        require(::change.isInitialized) { MISSING_CHANGE_INFO_MESSAGE }
         return change
-    }
-
-    fun comment(comment: String): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        }
+        
+        fun comment(comment: String): ChangeHandler {
+        require(::change.isInitialized) { MISSING_CHANGE_INFO_MESSAGE }
         if (comment.isNotEmpty()) {
-            logger.info { "Adding custom comment to change." }
-            changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
+        logger.info { "Adding custom comment to change." }
+        changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
         }
         return this
-    }
-
-    fun getComments(changeId: String): List<ChangeComment> {
+        }
+        
+        fun getComments(changeId: String): List<ChangeComment> {
         return changeManagementRepository.getComments(changeId, auth)
-    }
-
-    fun getUrl(): String {
-        require(::change.isInitialized) { "Missing required change information." }
+        }
+        
+        fun getUrl(): String {
+        require(::change.isInitialized) { MISSING_CHANGE_INFO_MESSAGE }
         val url = change.self
         requireNotNull(url)
         return url

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -1,5 +1,6 @@
 package de.deutschepost.sdm.cdlib.change.sharepoint
 
+import com.example.SharepointClient
 import de.deutschepost.sdm.cdlib.change.metrics.model.Webapproval
 import de.deutschepost.sdm.cdlib.change.sharepoint.model.*
 import de.deutschepost.sdm.cdlib.change.sharepoint.ntlm.JCIFSNTLMSchemeFactory
@@ -41,73 +42,73 @@ open class SharepointClient(private val user: String, private val password: Stri
 
     private fun getDigest(): String? {
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/contextinfo").apply {
-            addHeader("Accept", "application/json;odata=verbose")
-        }
-        return client.execute(httpPost).use { response ->
-            logger.info { "Getting Sharepoint Digest: ${response.statusLine}" }
-            val content = EntityUtils.toString(response.entity)
-            logger.debug { content }
-            if (response.statusLine.statusCode == HttpStatus.SC_OK) {
-                val sharepointContextWebInformation =
-                    permissiveObjectMapper.readValue(content, SharepointContextWebInformation::class.java)
-                sharepointContextWebInformation.getDigest()
-            } else {
-                null
+            addHeader("Accept", SharepointClient.APPLICATION_JSON_ODATA_VERBOSE)
             }
-        }
-    }
-
-    fun addEntryProd(approvalsListItem: SharepointApprovalsListItem) =
-        addEntry(approvalsListItem, ISHARE_PROD_LIST)
-
-    fun addEntryTest(approvalsListItem: SharepointApprovalsListItem): Webapproval {
-        val approvalsListItemTest = approvalsListItem.copy(metadata = SharepointApprovalsListItem.Metadata.TEST)
-        return addEntry(approvalsListItemTest, ISHARE_TEST_LIST)
-    }
-
-    private fun addEntry(
-        approvalsListItem: SharepointApprovalsListItem,
-        listName: String,
-    ): Webapproval {
-        val digest =
-            checkNotNull(getDigest()) {
-                """
-                Failed to get digest for Record.
-                This is eiter a connection issue or a credentials issue. You can check this with following command:
-                curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: application/json;odata=verbose\"""".trimIndent()
+            return client.execute(httpPost).use { response ->
+                logger.info { "Getting Sharepoint Digest: ${response.statusLine}" }
+                val content = EntityUtils.toString(response.entity)
+                logger.debug { content }
+                if (response.statusLine.statusCode == HttpStatus.SC_OK) {
+                    val sharepointContextWebInformation =
+                        permissiveObjectMapper.readValue(content, SharepointContextWebInformation::class.java)
+                    sharepointContextWebInformation.getDigest()
+                } else {
+                    null
+                }
             }
-
-        val webapprovalWithoutURL =
-            checkNotNull(verifyAndGenerateWebapproval(approvalsListItem.applicationId, listName == ISHARE_TEST_LIST)) {
-                "Failed validating approval documents."
+            
+            fun addEntryProd(approvalsListItem: SharepointApprovalsListItem) =
+                addEntry(approvalsListItem, ISHARE_PROD_LIST)
+            
+            fun addEntryTest(approvalsListItem: SharepointApprovalsListItem): Webapproval {
+                val approvalsListItemTest = approvalsListItem.copy(metadata = SharepointApprovalsListItem.Metadata.TEST)
+                return addEntry(approvalsListItemTest, ISHARE_TEST_LIST)
             }
-
-        val httpEntity = EntityBuilder.create().apply {
-            text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
-        }.build()
-        val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
-            addHeader("Accept", "application/json;odata=verbose")
-            addHeader("X-RequestDigest", digest)
-            addHeader("Content-Type", "application/json;odata=verbose")
-            entity = httpEntity
-        }
-
-        val webapprovalUrl = client.execute(httpPost).use { response ->
-            logger.info { "Adding Record: ${response.statusLine}" }
-            val content = EntityUtils.toString(response.entity)
-            logger.debug { content }
-
-            if (response.statusLine.statusCode != HttpStatus.SC_CREATED) {
-                logger.error { content }
-                throw IllegalStateException("Failed to create Record.")
-            } else {
-                val sharepointListItemId =
-                    permissiveObjectMapper.readValue(content, SharepointApprovalListItemId::class.java)
-                sharepointListItemId.getUrl(ISHARE_WEBAPPROVAL_BASE_URL, listName)
-            }
-        }
-        logger.info { "EntryUrl: $webapprovalUrl" }
-        return webapprovalWithoutURL.copy(url = webapprovalUrl)
+            
+            private fun addEntry(
+                approvalsListItem: SharepointApprovalsListItem,
+                listName: String,
+            ): Webapproval {
+                val digest =
+                    checkNotNull(getDigest()) {
+                        """
+                        Failed to get digest for Record.
+                        This is eiter a connection issue or a credentials issue. You can check this with following command:
+                        curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: ${SharepointClient.APPLICATION_JSON_ODATA_VERBOSE}\""".trimIndent()
+                    }
+            
+                val webapprovalWithoutURL =
+                    checkNotNull(verifyAndGenerateWebapproval(approvalsListItem.applicationId, listName == ISHARE_TEST_LIST)) {
+                        "Failed validating approval documents."
+                    }
+            
+                val httpEntity = EntityBuilder.create().apply {
+                    text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
+                }.build()
+                val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
+                    addHeader("Accept", SharepointClient.APPLICATION_JSON_ODATA_VERBOSE)
+                    addHeader("X-RequestDigest", digest)
+                    addHeader("Content-Type", SharepointClient.APPLICATION_JSON_ODATA_VERBOSE)
+                    entity = httpEntity
+                }
+            
+                val webapprovalUrl = client.execute(httpPost).use { response ->
+                    logger.info { "Adding Record: ${response.statusLine}" }
+                    val content = EntityUtils.toString(response.entity)
+                    logger.debug { content }
+            
+                    if (response.statusLine.statusCode != HttpStatus.SC_CREATED) {
+                        logger.error { content }
+                        throw IllegalStateException("Failed to create Record.")
+                    } else {
+                        val sharepointListItemId =
+                            permissiveObjectMapper.readValue(content, SharepointApprovalListItemId::class.java)
+                        sharepointListItemId.getUrl(ISHARE_WEBAPPROVAL_BASE_URL, listName)
+                    }
+                }
+                logger.info { "EntryUrl: $webapprovalUrl" }
+                return webapprovalWithoutURL.copy(url = webapprovalUrl)
+            
     }
 
 

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -21,12 +21,7 @@ data class LicenseBlackListEntry(
 )
 
 object OslcComplianceChecker : KLogging() {
-
-    private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
-    private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+    private const val NOT_FOUND = "not found"
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -3,17 +3,21 @@ package de.deutschepost.sdm.cdlib.utils
 import java.io.File
 import java.security.MessageDigest
 
+object Constants {
+    const val SHA_256_ALGORITHM = "SHA-256"
+}
+
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Constants.SHA_256_ALGORITHM)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Constants.SHA_256_ALGORITHM)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(Constants.SHA_256_ALGORITHM)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -76,8 +76,10 @@ class ChangeOslcIntegrationTest(
     override suspend fun beforeTest(testCase: io.kotest.core.test.TestCase) {
         super.beforeTest(testCase)
         envVariables["CDLIB_RELEASE_NAME_UNIQUE"] = "${releaseNameUnique}_${testCase.name.testName.replace(" ", "_")}"
+    const val ENTRY_URL_TEXT = "EntryUrl: "
+    
     }
-
+    
     init {
         context("Creating oslc change is a success") {
             test("change create --oslc missing distribution") {
@@ -89,18 +91,18 @@ class ChangeOslcIntegrationTest(
                 ret shouldBe -1
                 output shouldContain "IllegalArgumentException"
             }
-
+    
             test("change create with distribution") {
                 val (ret, output) = withStandardOutput {
                     val args =
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL_TEXT
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
             }
-
+    
             test("change create with report from maven plugin") {
                 val (ret, output) = withStandardOutput {
                     val args =

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -225,58 +225,59 @@ class ChangeCloseIntegrationTest(
                 output shouldContain "http://integration-test-url.jenkuns.example.com"
                 output shouldContain "Dashboard status code: 201"
                 exitCode shouldBeExactly 0
+            const val DASHBOARD_STATUS_MESSAGE = "Dashboard status code: 201"
+            
             }
-        }
-
-        "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
-            withEnvironment(
-                "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
-                    )
+            
+            "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
+                withEnvironment(
+                    "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                    OverrideMode.SetOrOverride
+                ) {
+                    changeHandler
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+            
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
+                        )
+                    }
+            
+                    output shouldContain "http://integration-test-url.jenkuns.example.com"
+                    output shouldContain DASHBOARD_STATUS_MESSAGE
+                    output shouldContain "INFRA"
+                    exitCode shouldBeExactly 0
                 }
-
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                output shouldContain "INFRA"
-                exitCode shouldBeExactly 0
             }
-        }
-
-        "Closing change successfully publishes metrics via AzureDevOps" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
-                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
-                }
-
-                output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
+            
+            "Closing change successfully publishes metrics via AzureDevOps" {
+                val rnd = UUID.randomUUID().toString().substringBefore("-")
+            
+                withEnvironment(
+                    mapOf(
+                        "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
+                        "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
+                    ),
+                    OverrideMode.SetOrOverride
+                ) {
+                    changeHandler
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+            
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                        )
+                    }
+            
+                    output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
+                    output shouldContain DASHBOARD_STATUS_MESSAGE
+                    exitCode shouldBeExactly 0
             }
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -71,30 +71,42 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
-        }
-
-        "Command fails if oslc but no distribution was passed" {
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CreateCommand::class.java,
-                    *"--jira-token $token --debug --commercial-reference 5296 --test".toArgsArray()
-                )
+            companion object {
+                const val ILLEGAL_ARGUMENT_EXCEPTION = "java.lang.IllegalArgumentException"
             }
-            exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
-        }
-
-        "Command doesn't fail if no-oslc and no distribution was passed" {
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CreateCommand::class.java,
-                    *"--jira-token $token --debug --commercial-reference 5296 --test --no-oslc".toArgsArray()
-                )
+            
+            "Command fails if webapproval is requested with missing parameters." {
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CreateCommand::class.java,
+                        *"--jira-token $token --debug --commercial-reference 5296 --test --webapproval --no-distribution".toArgsArray()
+                    )
+                }
+                exitCode shouldBeExactly -1
+                output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
             }
-            exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
-            output shouldContain "Verifying reports..."
+            
+            "Command fails if oslc but no distribution was passed" {
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CreateCommand::class.java,
+                        *"--jira-token $token --debug --commercial-reference 5296 --test".toArgsArray()
+                    )
+                }
+                exitCode shouldBeExactly -1
+                output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
+            }
+            
+            "Command doesn't fail if no-oslc and no distribution was passed" {
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CreateCommand::class.java,
+                        *"--jira-token $token --debug --commercial-reference 5296 --test --no-oslc".toArgsArray()
+                    )
+                }
+                exitCode shouldBeExactly -1
+                output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
+                output shouldContain "Verifying reports..."
         }
 
         "Parsing deployment status string returns expected enum" {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
@@ -82,308 +82,295 @@ class ChangeCreateIntegrationTest(
                         ctx,
                         *"change create --test --skip-approval-wait --jira-token $token --no-oslc --no-webapproval --no-tqs --commercial-reference $commercialReference".toArgsArray()
                     )
-                }
-                output shouldContain "CDLib version 0.2.0-INTEGRATION-TEST is not supported anymore. Please update to a newer version. Pre-authorization is not possible."
-                output shouldContain "A new version of CDLib is available"
-
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Could not find changes to close nor resume for the current pipeline"
-                output shouldContain "Posting change request"
-                output shouldContain "Determining whether change can be preauthorized."
-                output shouldContain "  CDLib version is supported: false\n" +
-                    "  Impact Class: ${NONE.name}\n" +
-                    "  Business Criticality: ${OPERATIONAL.name}\n" +
-                    "  Determined change type --> MINOR"
-                output shouldContain "Updating change request type: MINOR"
-                output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
-
-            }
-            changeTestHelper.closeChangeRequest(
-                token,
-                commercialReference
-            )
-        }
-
-        withMockedVersionInfo(changeHandler) {
-            test("Creating change via full change command fails given an invalid commercial reference") {
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference DI-123456".toArgsArray()
-                    )
-                }
-                output shouldContain "Failed to get commercial reference: DI-123456"
-            }
-
-            test("Change created with wrong parameters and --trace option extends logging") {
-                val (_, output) = withStandardOutput {
-                    val args: Array<String> =
-                        "change create --skip-approval-wait --jira-token wrong --no-oslc --no-webapproval --no-tqs --debug --trace --commercial-reference $commercialReference --test".toArgsArray()
-                    PicocliRunner.run(CdlibCommand::class.java, *args)
-                }
-
-                output shouldContain "TRACE"
-            }
-
-            test("Change create command with no open changes for the current pipeline continues successfully with appropriate log") {
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
-                    )
-                }
-
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Could not find changes to close nor resume for the current pipeline"
-                output shouldContain "Posting change request"
-                output shouldContain "Determining whether change can be preauthorized."
-                output shouldContain "  Impact Class: ${NONE.name}\n" +
-                    "  Business Criticality: ${OPERATIONAL.name}\n" +
-                    "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
-                output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
-                output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-
-
-
-                changeTestHelper.closeChangeRequest(token, commercialReference)
-            }
-
-            context("Change create command with custom details...") {
-                test("...and wrong category fails.") {
-                    val (_, output) = withErrorOutput {
-                        val toArgsArray = """change create
-                        | --category=wrongCategory
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
-                            .toArgsArray()
-                        PicocliRunner.run(
-                            CdlibCommand::class.java,
-                            *toArgsArray
-                        )
-                    }
-                    output shouldContain "Invalid value for option '--category': expected one of [ROLLOUT, NO_ROLLOUT, AUTHORIZATIONS, DATA_MAINTENANCE, TECHNICAL_REQUIREMENTS, LEGAL_OR_CONTRACTUAL_REQUIREMENTS, HOUSEKEEPING, CAPACITY_ADJUSTMENTS, SECURITY, TROUBLESHOOTING, OTHER] (case-sensitive) but was 'wrongCategory'"
-                }
-
-                test("...and wrong impactClass fails.") {
-                    val (_, output) = withErrorOutput {
-                        val toArgsArray = """change create
-                        | --impact-class=wrongImpactClass
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
-                            .toArgsArray()
-                        PicocliRunner.run(
-                            CdlibCommand::class.java,
-                            *toArgsArray
-                        )
-                    }
-
-                    output shouldContain "Invalid value for option '--impact-class': expected one of [CRITICAL, HIGH, LOW, MEDIUM, NONE] (case-sensitive) but was 'wrongImpactClass'"
-                }
-
-                test("...is successful with appropriate log and custom comment.") {
-                    val test = "test"
-                    val toArgsArray = """change create
-                        | --category $HOUSEKEEPING
-                        | --summary $test
-                        | --description $test
-                        | --impact-class $NONE
-                        | --impact $test
-                        | --target $test
-                        | --fallback $test
-                        | --implementation-risk $test
-                        | --omission-risk $test
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
-                        .toArgsArray()
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *toArgsArray
-                    )
-
-                    val change = changeHandler
-                        .findExisting()
-                        .findResumable()
-                        .getChange()
-
-                    change.category shouldBe HOUSEKEEPING
-                    change.summary shouldBe test
-                    change.description shouldBe test
-                    change.impactClass shouldBe NONE
-                    change.impact shouldBe test
-                    change.target shouldBe test
-                    change.fallback shouldBe test
-                    change.implementationRisk shouldBe test
-                    change.omissionRisk shouldBe test
-
-                    changeHandler.closeExisting()
-                }
-            }
-
-            test("Change create command with resume flag and changes open for the current pipeline closes all but the latest one and resumes that one successfully") {
-                withEnvironment(
-                    "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
-                    OverrideMode.SetOrOverride
-                ) {
-                    val changeDetails = changeTestHelper.changeDetailsWithDefaults()
-                    changeHandler
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                }
-
-                val (_, output) = withStandardOutput {
-                    withEnvironment(
-                        "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                        OverrideMode.SetOrOverride
-                    ) {
-                        PicocliRunner.run(
-                            CdlibCommand::class.java,
-                            *"change create --resume true --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
-                        )
-                    }
-                }
-
-                output shouldContain "Starting Change Management process."
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Closing change:"
-                output shouldContain "Adding abort comment to change..."
-                output shouldContain "Resuming change: "
-                output shouldContain "Adding resume comment to change..."
-                output shouldContain "Adding new job url to change description..."
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-                output shouldNotContain "Posting change request: "
-                output shouldNotContain "Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes."
-
-
-                changeTestHelper.closeChangeRequest(token, commercialReference)
-            }
-
-            test("Change create command with open changes that are awaiting implementation transitions them to 're-plan', cancels and then closes them") {
-
-                withEnvironment(
-                    "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
-                    OverrideMode.SetOrOverride
-                ) {
-                    changeHandler
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                }
-
-                val (_, output) = withStandardOutput {
-                    withEnvironment(
-                        "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                        OverrideMode.SetOrOverride
-                    ) {
-                        PicocliRunner.run(
-                            CdlibCommand::class.java,
-                            *"change create --test --skip-approval-wait --debug --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
-                        )
-                    }
-                }
-
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Closing change:"
-                output shouldContain "Rescheduling..."
-                output shouldContain "Cancelling..."
-                output shouldContain "Closing..."
-                output shouldContain "Adding abort comment to change..."
-                output shouldContain "Posting change request"
-                output shouldContain "Determining whether change can be preauthorized."
-                output shouldContain "  Impact Class: ${NONE.name}\n" +
-                    "  Business Criticality: ${OPERATIONAL.name}\n" +
-                    "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
-                output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
-                output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-                output shouldNotContain "Could not find changes to close nor resume for the current pipeline"
-
-                changeTestHelper.closeChangeRequest(token, commercialReference)
-            }
-
-            context("Change create command during frozen zone") {
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *"change create --test --skip-approval-wait --start=2023-01-01T00:00:00+01:00 --no-oslc --no-webapproval --no-tqs --enforce-frozen-zone --jira-token $token --commercial-reference $commercialReference".toArgsArray()
-                    )
-                }
-
-                test("...creates a change and progresses it regularly") {
-                    output shouldContain "Retrieving IT system information"
-                    output shouldContain "Searching existing changes for the current pipeline"
-                    output shouldContain "Posting change request"
-                }
-
-                test("...ignores custom change window.") {
-                    output shouldContain "Frozen zone active: Ignoring set custom change window."
-                }
-
-                test("...recognises frozen zone") {
-                    output shouldContain "Determining whether change can be preauthorized."
-                    output shouldContain "  Impact Class: ${NONE.name}\n" +
-                        "  Business Criticality: ${OPERATIONAL.name}\n" +
-                        "  Special conditions:\n" +
-                        "    Frozen Zone (i.e. Starkverkehr) is active from "
-                }
-
-                test("...updates change type to major") {
-                    output shouldContain "  Determined change type --> ${MAJOR.name}"
-                    output shouldContain "Updating change request type: ${MAJOR.name}"
-                }
-
-                test("...and does not preauthorize nor approve it") {
-                    output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                    output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
-                    output shouldNotContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-                    output shouldNotContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
-                }
-
-                changeTestHelper.closeChangeRequest(token, commercialReference)
-            }
-
-            context("Change create with custom change window...") {
-                val now = ZonedDateTime.now()
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *("change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token " +
-                            "--commercial-reference $commercialReference " +
-                            "--start ${now.toIso()} " +
-                            "--end ${now.plusDays(2).toIso()}").toArgsArray(),
-                    )
-                }
-
-                test("...creates a change and progresses it regularly") {
-
-                    output shouldContain "Retrieving IT system information"
-                    output shouldContain "Searching existing changes for the current pipeline"
-                    output shouldContain "Could not find changes to close nor resume for the current pipeline"
-                    output shouldContain "Posting change request"
-                    output shouldContain "Determining whether change can be preauthorized."
-                    output shouldContain "  Impact Class: ${NONE.name}\n" +
-                        "  Business Criticality: ${OPERATIONAL.name}\n" +
-                        "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
-                    output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
-                    output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                    output shouldContain "Checking change request status for approval every "
-                    output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                companion object {
+                       const val CHECKING_STATUS_MESSAGE = "Checking change request status for approval every "
+                   }
+                
+                } 
+                
+                changeTestHelper.closeChangeRequest(
+                   token,
+                   commercialReference
+                )
+                
+                withMockedVersionInfo(changeHandler) {
+                   test("Creating change via full change command fails given an invalid commercial reference") {
+                       val (_, output) = withStandardOutput {
+                           PicocliRunner.run(
+                               CdlibCommand::class.java,
+                               *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference DI-123456".toArgsArray()
+                           )
+                       }
+                       output shouldContain "Failed to get commercial reference: DI-123456"
+                   }
+                
+                   test("Change created with wrong parameters and --trace option extends logging") {
+                       val (_, output) = withStandardOutput {
+                           val args: Array<String> =
+                               "change create --skip-approval-wait --jira-token wrong --no-oslc --no-webapproval --no-tqs --debug --trace --commercial-reference $commercialReference --test".toArgsArray()
+                           PicocliRunner.run(CdlibCommand::class.java, *args)
+                       }
+                
+                       output shouldContain "TRACE"
+                   }
+                
+                   test("Change create command with no open changes for the current pipeline continues successfully with appropriate log") {
+                       val (_, output) = withStandardOutput {
+                           PicocliRunner.run(
+                               CdlibCommand::class.java,
+                               *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
+                           )
+                       }
+                
+                       output shouldContain "Retrieving IT system information"
+                       output shouldContain "Searching existing changes for the current pipeline"
+                       output shouldContain "Could not find changes to close nor resume for the current pipeline"
+                       output shouldContain "Posting change request"
+                       output shouldContain "Determining whether change can be preauthorized."
+                       output shouldContain "  Impact Class: ${NONE.name}\n" +
+                           "  Business Criticality: ${OPERATIONAL.name}\n" +
+                           "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
+                       output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
+                       output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
+                       output shouldContain CHECKING_STATUS_MESSAGE
+                       output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                
+                
+                
+                       changeTestHelper.closeChangeRequest(token, commercialReference)
+                   }
+                
+                   context("Change create command with custom details...") {
+                       test("...and wrong category fails.") {
+                           val (_, output) = withErrorOutput {
+                               val toArgsArray = """change create
+                               | --category=wrongCategory
+                               | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                               | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                                   .toArgsArray()
+                               PicocliRunner.run(
+                                   CdlibCommand::class.java,
+                                   *toArgsArray
+                               )
+                           }
+                           output shouldContain "Invalid value for option '--category': expected one of [ROLLOUT, NO_ROLLOUT, AUTHORIZATIONS, DATA_MAINTENANCE, TECHNICAL_REQUIREMENTS, LEGAL_OR_CONTRACTUAL_REQUIREMENTS, HOUSEKEEPING, CAPACITY_ADJUSTMENTS, SECURITY, TROUBLESHOOTING, OTHER] (case-sensitive) but was 'wrongCategory'"
+                       }
+                
+                       test("...and wrong impactClass fails.") {
+                           val (_, output) = withErrorOutput {
+                               val toArgsArray = """change create
+                               | --impact-class=wrongImpactClass
+                               | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                               | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                                   .toArgsArray()
+                               PicocliRunner.run(
+                                   CdlibCommand::class.java,
+                                   *toArgsArray
+                               )
+                           }
+                
+                           output shouldContain "Invalid value for option '--impact-class': expected one of [CRITICAL, HIGH, LOW, MEDIUM, NONE] (case-sensitive) but was 'wrongImpactClass'"
+                       }
+                
+                       test("...is successful with appropriate log and custom comment.") {
+                           val test = "test"
+                           val toArgsArray = """change create
+                               | --category $HOUSEKEEPING
+                               | --summary $test
+                               | --description $test
+                               | --impact-class $NONE
+                               | --impact $test
+                               | --target $test
+                               | --fallback $test
+                               | --implementation-risk $test
+                               | --omission-risk $test
+                               | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                               | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                               .toArgsArray()
+                           PicocliRunner.run(
+                               CdlibCommand::class.java,
+                               *toArgsArray
+                           )
+                
+                           val change = changeHandler
+                               .findExisting()
+                               .findResumable()
+                               .getChange()
+                
+                           change.category shouldBe HOUSEKEEPING
+                           change.summary shouldBe test
+                           change.description shouldBe test
+                           change.impactClass shouldBe NONE
+                           change.impact shouldBe test
+                           change.target shouldBe test
+                           change.fallback shouldBe test
+                           change.implementationRisk shouldBe test
+                           change.omissionRisk shouldBe test
+                
+                           changeHandler.closeExisting()
+                       }
+                   }
+                
+                   test("Change create command with resume flag and changes open for the current pipeline closes all but the latest one and resumes that one successfully") {
+                       withEnvironment(
+                           "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
+                           OverrideMode.SetOrOverride
+                       ) {
+                           val changeDetails = changeTestHelper.changeDetailsWithDefaults()
+                           changeHandler
+                               .post(changeDetails)
+                               .preauthorize()
+                               .transition(OPEN_TO_IMPLEMENTATION)
+                               .post(changeDetails)
+                               .preauthorize()
+                               .transition(OPEN_TO_IMPLEMENTATION)
+                       }
+                
+                       val (_, output) = withStandardOutput {
+                           withEnvironment(
+                               "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                               OverrideMode.SetOrOverride
+                           ) {
+                               PicocliRunner.run(
+                                   CdlibCommand::class.java,
+                                   *"change create --resume true --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
+                               )
+                           }
+                       }
+                
+                       output shouldContain "Starting Change Management process."
+                       output shouldContain "Retrieving IT system information"
+                       output shouldContain "Searching existing changes for the current pipeline"
+                       output shouldContain "Closing change:"
+                       output shouldContain "Adding abort comment to change..."
+                       output shouldContain "Resuming change: "
+                       output shouldContain "Adding resume comment to change..."
+                       output shouldContain "Adding new job url to change description..."
+                       output shouldContain CHECKING_STATUS_MESSAGE
+                       output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                       output shouldNotContain "Posting change request: "
+                       output shouldNotContain "Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes."
+                
+                
+                       changeTestHelper.closeChangeRequest(token, commercialReference)
+                   }
+                
+                   test("Change create command with open changes that are awaiting implementation transitions them to 're-plan', cancels and then closes them") {
+                
+                       withEnvironment(
+                           "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
+                           OverrideMode.SetOrOverride
+                       ) {
+                           changeHandler
+                               .post(changeDetails)
+                               .preauthorize()
+                               .transition(OPEN_TO_IMPLEMENTATION)
+                               .post(changeDetails)
+                               .preauthorize()
+                               .transition(OPEN_TO_IMPLEMENTATION)
+                       }
+                
+                       val (_, output) = withStandardOutput {
+                           withEnvironment(
+                               "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                               OverrideMode.SetOrOverride
+                           ) {
+                               PicocliRunner.run(
+                                   CdlibCommand::class.java,
+                                   *"change create --test --skip-approval-wait --debug --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
+                               )
+                           }
+                       }
+                
+                       output shouldContain "Retrieving IT system information"
+                       output shouldContain "Searching existing changes for the current pipeline"
+                       output shouldContain "Closing change:"
+                       output shouldContain "Rescheduling..."
+                       output shouldContain "Cancelling..."
+                       output shouldContain "Closing..."
+                       output shouldContain "Adding abort comment to change..."
+                       output shouldContain "Posting change request"
+                       output shouldContain "Determining whether change can be preauthorized."
+                       output shouldContain "  Impact Class: ${NONE.name}\n" +
+                           "  Business Criticality: ${OPERATIONAL.name}\n" +
+                           "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
+                       output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
+                       output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
+                       output shouldContain CHECKING_STATUS_MESSAGE
+                       output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                       output shouldNotContain "Could not find changes to close nor resume for the current pipeline"
+                
+                       changeTestHelper.closeChangeRequest(token, commercialReference)
+                   }
+                
+                   context("Change create command during frozen zone") {
+                       val (_, output) = withStandardOutput {
+                           PicocliRunner.run(
+                               CdlibCommand::class.java,
+                               *"change create --test --skip-approval-wait --start=2023-01-01T00:00:00+01:00 --no-oslc --no-webapproval --no-tqs --enforce-frozen-zone --jira-token $token --commercial-reference $commercialReference".toArgsArray()
+                           )
+                       }
+                
+                       test("...creates a change and progresses it regularly") {
+                           output shouldContain "Retrieving IT system information"
+                           output shouldContain "Searching existing changes for the current pipeline"
+                           output shouldContain "Posting change request"
+                       }
+                
+                       test("...ignores custom change window.") {
+                           output shouldContain "Frozen zone active: Ignoring set custom change window."
+                       }
+                
+                       test("...recognises frozen zone") {
+                           output shouldContain "Determining whether change can be preauthorized."
+                           output shouldContain "  Impact Class: ${NONE.name}\n" +
+                               "  Business Criticality: ${OPERATIONAL.name}\n" +
+                               "  Special conditions:\n" +
+                               "    Frozen Zone (i.e. Starkverkehr) is active from "
+                       }
+                
+                       test("...updates change type to major") {
+                           output shouldContain "  Determined change type --> ${MAJOR.name}"
+                           output shouldContain "Updating change request type: ${MAJOR.name}"
+                       }
+                
+                       test("...and does not preauthorize nor approve it") {
+                           output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
+                           output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
+                           output shouldNotContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                           output shouldNotContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
+                       }
+                
+                       changeTestHelper.closeChangeRequest(token, commercialReference)
+                   }
+                
+                   context("Change create with custom change window...") {
+                       val now = ZonedDateTime.now()
+                       val (_, output) = withStandardOutput {
+                           PicocliRunner.run(
+                               CdlibCommand::class.java,
+                               *("change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token " +
+                                   "--commercial-reference $commercialReference " +
+                                   "--start ${now.toIso()} " +
+                                   "--end ${now.plusDays(2).toIso()}").toArgsArray(),
+                           )
+                       }
+                
+                       test("...creates a change and progresses it regularly") {
+                
+                           output shouldContain "Retrieving IT system information"
+                           output shouldContain "Searching existing changes for the current pipeline"
+                           output shouldContain "Could not find changes to close nor resume for the current pipeline"
+                           output shouldContain "Posting change request"
+                           output shouldContain "Determining whether change can be preauthorized."
+                           output shouldContain "  Impact Class: ${NONE.name}\n" +
+                               "  Business Criticality: ${OPERATIONAL.name}\n" +
+                               "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
+                           output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
+                           output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
+                           output shouldContain CHECKING_STATUS_MESSAGE
+                           output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                       }
                 }
 
                 test("...exits when change window is over on a resume run") {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -184,7 +184,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_CRITICALITY,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -196,7 +196,7 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_CRITICALITY,
                                                 6
                                             ),
                                             objectKey = "objectKey",

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
@@ -29,6 +29,9 @@ class NameResolverAzureTest(
     private val resolver: NameResolverAzure,
     private val namesConfigWithDefault: NamesConfigWithDefault
 ) : AnnotationSpec() {
+    companion object {
+        const val SDM_PHIPPY_FRIENDS = "ICTO-3339_SDM-phippyandfriends"
+    }
     private val before = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toInstant()
 
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -52,6 +52,9 @@ class NamesCommandAzureTest : AnnotationSpec() {
             committerName = "Firstname Committer",
             committerEmail = "f.c@dhl.com"
         )
+
+    companion object {
+        const val CDLIB_APP_NAME = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
     }
 
     @Test
@@ -61,7 +64,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
 
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase CDLIB_APP_NAME
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -12,13 +12,17 @@ import withStandardOutput
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class NamesCommandTest : DescribeSpec({
+    companion object {
+        const val HELP_DISPLAY_TEXT = "should display help"
+    }
+
     describe("cdlib names") {
         describe("names -h") {
             val (_, output) = withStandardOutput {
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(HELP_DISPLAY_TEXT) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }
@@ -29,7 +33,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(HELP_DISPLAY_TEXT) {
                 output shouldContain "Create canonical set of standard names and IDs"
                 output shouldContain "Name of optional output file"
                 output shouldContain "Release name to use for derived name creation"
@@ -43,7 +47,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(HELP_DISPLAY_TEXT) {
                 output shouldContain "Dumps the list of environment variables"
                 output shouldContain "Name of optional output file"
             }
@@ -61,4 +65,5 @@ class NamesCommandTest : DescribeSpec({
             }
         }
     }
+})
 })

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockkObject
 @Tags("UnitTest")
 class RepositoryTest : AnnotationSpec() {
     private val currDir = System.getProperty("user.dir")
+    private val EMAIL = "f.l@dhl.com"
 
     @BeforeAll
     fun initMocks() {
@@ -22,9 +23,9 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = EMAIL,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = EMAIL
         )
     }
 
@@ -35,9 +36,10 @@ class RepositoryTest : AnnotationSpec() {
         revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.authorEmail shouldBeEqualComparingTo EMAIL
         revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.committerEmail shouldBeEqualComparingTo EMAIL
+    }
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -51,7 +51,7 @@ class ReportOslcGradlePluginIntegrationTest(
                 ret shouldBeExactly 0
                 output shouldContain "Policy Profile: Non-Distribution"
             }
-
+    
             test("Upload OSLC-Plugin report to artifactory") {
                 val args =
                     "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
@@ -61,17 +61,17 @@ class ReportOslcGradlePluginIntegrationTest(
                 ret shouldBeExactly 0
                 output shouldContain "Uploaded Artifact:"
             }
-
+    
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
                 val args = "--debug --files $jsonFile --distribution".toArgsArray()
                 val (ret, output) = withStandardOutput {
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldNotContain "Unapproved Licenses Count: 0"
             }
-
+    
             test("Check OSLC-Plugin report locally should succeed with accepted list") {
                 val args =
                     "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFile".toArgsArray()
@@ -79,10 +79,10 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 0"
             }
-
+    
             test("Check OSLC-Plugin report locally should fail with accepted list because of wrong license") {
                 val args =
                     "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongLicense".toArgsArray()
@@ -90,11 +90,11 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
             }
-
+    
             test("Check OSLC-Plugin report locally should fail with accepted list because of wrong version number") {
                 val args =
                     "--debug --files $jsonFile --distribution --oslc-accepted-list $acceptedListFileWrongVersion".toArgsArray()
@@ -102,10 +102,12 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
             }
+        }
+    }
 
             test("Trying to upload failing OSLC-Plugin report to artifactory should missing") {
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -22,7 +22,6 @@ class ReportOslcNPMPluginIntegrationTest(
     @Value("\${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
     @Value("\${artifactory-azure-identity-token}") val artifactoryLCMIdentityToken: String,
 ) : FunSpec() {
-
     private val appName = "cli"
     private val releaseName = "Integration_result_0228"
     private val jsonFile = "src/test/resources/passing/${TestResultPrefixes.DEFAULT_PREFIX_OSLC_NPM_PLUGIN}.json"
@@ -30,7 +29,8 @@ class ReportOslcNPMPluginIntegrationTest(
         "src/test/resources/oslc/${TestResultPrefixes.DEFAULT_PREFIX_OSLC_NPM_PLUGIN}_failing.json"
     private val repoName = "sdm-proj-prg-cdlib-cli-appimage"
     private val repoLCMName = "ICTO-3339_sdm_sockshop_release_reports"
-
+    private val uploadedArtifactMessage = "Uploaded Artifact:"
+    
     override fun listeners() = listOf(
         getSystemEnvironmentTestListenerWithOverrides(
             mapOf(
@@ -39,7 +39,7 @@ class ReportOslcNPMPluginIntegrationTest(
             )
         )
     )
-
+    
     init {
         context("Check OSLC-Plugin report and upload") {
             test("Check OSLC-Plugin report locally") {
@@ -50,7 +50,7 @@ class ReportOslcNPMPluginIntegrationTest(
                 ret shouldBeExactly 0
                 output shouldContain "Policy Profile: Non-Distribution"
             }
-
+    
             test("Upload OSLC-Plugin report to artifactory") {
                 val args =
                     "--debug --files $jsonFile --no-distribution --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --type build".toArgsArray()
@@ -58,7 +58,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain uploadedArtifactMessage
             }
             // TODO: Delete after sundown
             test("Upload OSLC-Plugin report to LCM artifactory") {
@@ -68,7 +68,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain uploadedArtifactMessage
             }
 
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -23,12 +23,14 @@ import java.io.File
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class FnciReportTest : FunSpec({
-    val projectPath = "src/test/resources/fnci/fnci-project.json"
+    companion object {
+        const val PROJECT_PATH = "src/test/resources/fnci/fnci-project.json"
+    }
     val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
     context("Project Info") {
         test("Parses projectInfo correctly") {
             val projectInfo = permissiveObjectMapper.readValue(
-                File(projectPath), FnciProjectInfoWrapper::class.java
+                File(PROJECT_PATH), FnciProjectInfoWrapper::class.java
             ).data
             projectInfo.policyProfileName shouldBe "Non-Distribution insecure"
             defaultObjectMapper.writeValue(System.out, projectInfo)
@@ -48,11 +50,11 @@ class FnciReportTest : FunSpec({
 
     context("OslcTestResult") {
         val projectInfo: FnciProjectInfo =
-            permissiveObjectMapper.readValue(File(projectPath), FnciProjectInfoWrapper::class.java).data
+            permissiveObjectMapper.readValue(File(PROJECT_PATH), FnciProjectInfoWrapper::class.java).data
         val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
         test("Generate OslcTestResult") {
             val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
+                OslcTestResult.from(FnciTestResult(projectInfo, inventory), PROJECT_PATH)
             report.complianceStatus shouldBe OslcComplianceStatus.RED
             report.unapprovedItems.shouldNotBeEmpty()
             defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
@@ -61,7 +63,7 @@ class FnciReportTest : FunSpec({
         test("Only approved is compliant") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                PROJECT_PATH
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()
@@ -71,7 +73,7 @@ class FnciReportTest : FunSpec({
         test("Canonical file name should depend on project, not files") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                PROJECT_PATH
             )
             report.canonicalFilename shouldEndWith "${report.projectName}.json"
         }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -41,12 +41,16 @@ class OslcComplianceAcceptedListTest : FunSpec() {
         )
     )
 
+    companion object {
+        const val INPUT_STRING_HEADER = "Input String"
+    }
+
     init {
         context("de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.VersionSpecification parsing") {
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
+                        headers(INPUT_STRING_HEADER, "Default Value", "Expected"),
                         row("0.0.0", 0, VersionSpecification(0, 0, 0)),
                         row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
                         row("1.2.3", 0, VersionSpecification(1, 2, 3)),
@@ -62,7 +66,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing invalid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value"),
+                        headers(INPUT_STRING_HEADER, "Default Value"),
                         row("a.b.c", 0),
                         row("error", 0),
                         row("3,2,5", 0),
@@ -75,7 +79,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
+                        headers(INPUT_STRING_HEADER, "ExpectedMin", "ExpectedMax"),
                         row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
                         row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
                         row(
@@ -104,7 +108,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing invalid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String"),
+                        headers(INPUT_STRING_HEADER),
                         row("1.2.3-11.12.13-1.2.3"),
                         row("1-1-1"),
                     )

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
@@ -38,7 +38,8 @@ class OslcComplianceCheckerTest : FunSpec() {
             )
         )
     )
-    private val licenseMozillaName = "Mozilla Public License 2.0"
+    private val MOZILLA_PUBLIC_LICENSE = "Mozilla Public License 2.0"
+    private val licenseMozillaName = MOZILLA_PUBLIC_LICENSE
     private val depWithCDDL = OslcDependencyLicenseEntry(
         dependencyName = "test.should.fail:cddl",
         dependencyVersion = "",
@@ -63,6 +64,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         )
     )
     private val licenseLGPL21Name = "GNU Lesser General Public License 2.1"
+
     private val depWithLGPL3 = OslcDependencyLicenseEntry(
         dependencyName = "test.should.fail:lgpl3",
         dependencyVersion = "",


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
