### PR TITLE
Sonar: Make this interface functional or replace it with a function type. (rule kotlin:S6517)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointGraphClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointGraphClient.kt
@@ -16,7 +16,7 @@ import io.micronaut.retry.annotation.Retryable
 
 @Client(SHAREPOINT_GRAPH_URL, configuration = O365Configuration::class)
 @Retryable
-interface SharepointGraphClient {
+fun interface SharepointGraphClient {
     @Post("/{siteId}/lists/{listId}/items")
     fun addEntry(
         siteId: String,

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderFactory.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderFactory.kt
@@ -2,7 +2,7 @@ package de.deutschepost.sdm.cdlib.names
 
 import jakarta.inject.Singleton
 
-interface NameProviderFactory {
+fun interface NameProviderFactory {
     fun getProvider(providerType: PlatformType = currentPlatformType): NameProvider
 }
 


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: 371d489

### Rule Description: 
<p>Replace <code>interface</code> with <code>fun interface</code>. If the interface is annotated with <code>@FunctionalInterface</code>, remove the
annotation.</p>

<h4>Noncompliant code example</h4>
<pre data-diff-id="1" data-diff-type="noncompliant">
interface IntMapper&lt;T&gt; { // Noncompliant
    fun map(value: Int): T
}

interface StringMapper&lt;T&gt; { // Noncompliant
    fun map(value: String): T
}

@FunctionalInterface  // Noncompliant
interface ProgressCallback {
    fun progressChanged(percent: Double)
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
fun interface IntMapper&lt;T&gt; { // Compliant, function interface used
    fun map(value: Int): T
}

typealias StringMapper&lt;T&gt; = (value: String) -&gt; T // Compliant, functional type used

fun interface ProgressCallback { // Compliant, function interface used
    fun progressChanged(percent: Double)
}
</pre>
<p>An interface that declares only a single function should be marked as function interface. Function interfaces can be instantiated from lambda
expressions directly and are, therefore, more comfortable to use.</p>
<p>Also, consider using a function type instead of a function interface. In many situations, a function type is sufficient. A function interface is
only required when the function must not be anonymous or when an object should implement multiple function interfaces at once.</p>
<h3>What is the potential impact?</h3>
<h4>Complexity</h4>
<p>When an interface is declared <em>functional</em>, SAM conversion is enabled. This means that any lambda expression that matches the interface’s
single function’s signature can be converted into an instance of the interface, without the need for an explicit class or singleton object to
implement the interface.</p>
<h4>Wrong logic</h4>
<p>An interface can still be marked <code>@FunctionalInterface</code> in Kotlin, but this has no effect, and SAM conversion will not work. The
annotation <code>java.lang.FunctionalInterface</code> is only a Java platform type with no special meaning in Kotlin.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/names/NameProviderFactory.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointGraphClient.kt
