### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -247,13 +247,17 @@ class ChangeHandler(
         return this
     }
 
+    companion object {
+        private const val MISSING_CHANGE_INFO = "Missing required change information."
+    }
+    
     fun preauthorize(): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
         logger.info { "Determining whether change can be preauthorized." }
         val changeType = determineChangeType()
         logTypeResults(changeType)
         change = change.updateType(changeType)
-
+    
         runCatching {
             logger.info { "Updating change request type: ${change.type?.name}" }
             changeManagementRepository.updateChange(change, auth)
@@ -262,32 +266,32 @@ class ChangeHandler(
         }
         return this
     }
-
+    
     fun resume(): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
+    
         logger.info { "Resuming change: ${change.self}" }
         logger.info { "Adding resume comment to change..." }
-
+    
         changeManagementRepository.addComment(
             change.id,
             "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
             auth
         )
-
+    
         logger.info { "Adding new job url to change description..." }
         change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
-
+    
         changeManagementRepository.updateChange(change, auth)
-
+    
         return this
     }
-
+    
     fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
+    
         runCatching {
             logger.info { "Transitioning change request phase: ${phase.name}" }
             changeManagementRepository.transitionChangePhase(
@@ -298,26 +302,26 @@ class ChangeHandler(
         }.onFailure {
             it.klogSelf(logger)
         }.getOrThrow()
-
+    
         return this
     }
-
+    
     fun monitor(approvalCheckInterval: Int): ChangeHandler {
         require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
+    
         val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
         logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
-
+    
         for (i in 1..numberOfApprovalChecks) {
             val changeRequest = runCatching {
                 changeManagementRepository.getChangeRequest(change.id, auth)
             }.onFailure {
                 it.klogSelf(logger)
             }.getOrThrow()
-
+    
             logChangeRequestStatus(changeRequest)
-
+    
             if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
                 return this
             }
@@ -325,37 +329,39 @@ class ChangeHandler(
         }
         throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
     }
-
+    
     fun getItSystem(): ItSystem {
         require(::itSystem.isInitialized) {
             "Missing required IT system information."
         }
         return itSystem
     }
-
+    
     fun getChange(): Change {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
         return change
     }
-
+    
     fun comment(comment: String): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
         if (comment.isNotEmpty()) {
             logger.info { "Adding custom comment to change." }
             changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
         }
         return this
     }
-
+    
     fun getComments(changeId: String): List<ChangeComment> {
         return changeManagementRepository.getComments(changeId, auth)
     }
-
+    
     fun getUrl(): String {
-        require(::change.isInitialized) { "Missing required change information." }
+        require(::change.isInitialized) { MISSING_CHANGE_INFO }
         val url = change.self
         requireNotNull(url)
         return url
+    }
+    
     }
 
     private fun logChangeRequestStatus(changeRequest: Change) {

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -41,7 +41,7 @@ open class SharepointClient(private val user: String, private val password: Stri
 
     private fun getDigest(): String? {
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/contextinfo").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", APPLICATION_JSON_ODATA_VERBOSE)
         }
         return client.execute(httpPost).use { response ->
             logger.info { "Getting Sharepoint Digest: ${response.statusLine}" }
@@ -56,15 +56,15 @@ open class SharepointClient(private val user: String, private val password: Stri
             }
         }
     }
-
+    
     fun addEntryProd(approvalsListItem: SharepointApprovalsListItem) =
         addEntry(approvalsListItem, ISHARE_PROD_LIST)
-
+    
     fun addEntryTest(approvalsListItem: SharepointApprovalsListItem): Webapproval {
         val approvalsListItemTest = approvalsListItem.copy(metadata = SharepointApprovalsListItem.Metadata.TEST)
         return addEntry(approvalsListItemTest, ISHARE_TEST_LIST)
     }
-
+    
     private fun addEntry(
         approvalsListItem: SharepointApprovalsListItem,
         listName: String,
@@ -72,31 +72,31 @@ open class SharepointClient(private val user: String, private val password: Stri
         val digest =
             checkNotNull(getDigest()) {
                 """
-                Failed to get digest for Record.
-                This is eiter a connection issue or a credentials issue. You can check this with following command:
-                curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: application/json;odata=verbose\"""".trimIndent()
+                    Failed to get digest for Record.
+                    This is eiter a connection issue or a credentials issue. You can check this with following command:
+                    curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: application/json;odata=verbose\""".trimIndent()
             }
-
+    
         val webapprovalWithoutURL =
             checkNotNull(verifyAndGenerateWebapproval(approvalsListItem.applicationId, listName == ISHARE_TEST_LIST)) {
                 "Failed validating approval documents."
             }
-
+    
         val httpEntity = EntityBuilder.create().apply {
             text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
         }.build()
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", APPLICATION_JSON_ODATA_VERBOSE)
             addHeader("X-RequestDigest", digest)
-            addHeader("Content-Type", "application/json;odata=verbose")
+            addHeader("Content-Type", APPLICATION_JSON_ODATA_VERBOSE)
             entity = httpEntity
         }
-
+    
         val webapprovalUrl = client.execute(httpPost).use { response ->
             logger.info { "Adding Record: ${response.statusLine}" }
             val content = EntityUtils.toString(response.entity)
             logger.debug { content }
-
+    
             if (response.statusLine.statusCode != HttpStatus.SC_CREATED) {
                 logger.error { content }
                 throw IllegalStateException("Failed to create Record.")
@@ -109,8 +109,8 @@ open class SharepointClient(private val user: String, private val password: Stri
         logger.info { "EntryUrl: $webapprovalUrl" }
         return webapprovalWithoutURL.copy(url = webapprovalUrl)
     }
-
-
+    
+    
     fun verifyAndGenerateWebapproval(applicationId: Int, isTest: Boolean): Webapproval? {
         val sharepointApprovalConfiguration = getSharepointApprovalConfigurations().findById(applicationId)
         logger.info { "Getting approvalStatus for ApplicationID $applicationId" }
@@ -118,12 +118,12 @@ open class SharepointClient(private val user: String, private val password: Stri
             sharepointApprovalConfiguration?.status == null -> {
                 logger.error {
                     """Cannot find valid pipeline configuration entry for ApplicationID $applicationId
-                    Did you already request one: $ISHARE_WEBAPPROVAL_BASE_URL/Lists/Pipeline%20Approval%20Configuration/AllItems.aspx
-                    """.trimIndent()
+                        Did you already request one: $ISHARE_WEBAPPROVAL_BASE_URL/Lists/Pipeline%20Approval%20Configuration/AllItems.aspx
+                        """.trimIndent()
                 }
                 return null
             }
-
+    
             sharepointApprovalConfiguration.status != "Approved" -> {
                 val logMessage =
                     "ApprovalStatus of ApplicationID $applicationId is ${sharepointApprovalConfiguration.status} and not Approved!"
@@ -134,12 +134,12 @@ open class SharepointClient(private val user: String, private val password: Stri
                     return null
                 }
             }
-
+    
             else -> {
                 logger.info { "ApprovalStatus of ApplicationID is ${sharepointApprovalConfiguration.status}" }
             }
         }
-
+    
         val webapplication = Webapproval.Webapplication(
             certification = Webapproval.Webapplication.Certification(
                 id = applicationId,
@@ -147,27 +147,27 @@ open class SharepointClient(private val user: String, private val password: Stri
             ),
             sharepointUrl = "$ISHARE_WEBAPPLICATION_BY_ID_URL${sharepointApprovalConfiguration.listId}"
         )
-
+    
         return Webapproval(
             url = "$ISHARE_WEBAPPROVAL_BASE_URL${if (isTest) ISHARE_TEST_LIST else ISHARE_PROD_LIST}/AllItems.aspx",
             webapplication = webapplication,
         )
     }
-
+    
     private fun getSharepointApprovalConfigurations(): SharepointApprovalConfigurations {
         val httpGet =
             HttpGet("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approval%20Configuration')/items").apply {
-                addHeader("Accept", "application/json;odata=verbose")
+                addHeader("Accept", APPLICATION_JSON_ODATA_VERBOSE)
             }
         client.execute(httpGet).use { response ->
             logger.info { "Executed request ${httpGet.requestLine} --- ${response.statusLine}" }
             val content = EntityUtils.toString(response.entity)
             logger.debug { content }
-
+    
             return permissiveObjectMapper.readValue(content, SharepointApprovalConfigurations::class.java)
         }
     }
-
+    
     companion object : KLogging() {
         const val ISHARE_BASE_URL = "https://itm.prg-dc.dhl.com"
         const val ISHARE_WEBAPPROVAL_BASE_URL = "${ISHARE_BASE_URL}/sites/it-sec"
@@ -175,5 +175,6 @@ open class SharepointClient(private val user: String, private val password: Stri
         const val ISHARE_TEST_LIST = "Pipeline%20Approvals%20TEST"
         const val ISHARE_WEBAPPLICATION_BY_ID_URL =
             "https://itm.prg-dc.dhl.com/sites/it-sec/Lists/Pipeline%20Approval%20Configuration/DispForm.aspx?ID="
+        const val APPLICATION_JSON_ODATA_VERBOSE = "application/json;odata=verbose"
     }
-}
+    

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -21,12 +21,13 @@ data class LicenseBlackListEntry(
 )
 
 object OslcComplianceChecker : KLogging() {
-
-    private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
-    private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+    object OslcComplianceChecker : KLogging() {
+        private const val NOT_FOUND_MESSAGE = "not found"
+        private val disallowedLicensesDistributionPath: String =
+            javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: NOT_FOUND_MESSAGE
+        private val disallowedLicensesNonDistributionPath: String =
+            javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: NOT_FOUND_MESSAGE
+        private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: NOT_FOUND_MESSAGE
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -2,18 +2,19 @@ package de.deutschepost.sdm.cdlib.utils
 
 import java.io.File
 import java.security.MessageDigest
+private const val SHA_256 = "SHA-256"
 
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -96,33 +96,35 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
-            }
-
-            test("change create with report from maven plugin") {
-                val (ret, output) = withStandardOutput {
-                    val args =
-                        "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
-                    PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
-                output shouldContain "labels=[cdlib, oslc, test]"
-                output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
-                ret shouldBeExactly 0
-            }
-
-            test("change create with report from gradle plugin") {
-                val (ret, output) = withStandardOutput {
-                    val args =
-                        "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcGradlePluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
-                    PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
+                
+                test("change create with report from maven plugin") {
+                    val (ret, output) = withStandardOutput {
+                        val args =
+                            "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
+                        PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
+                    }
+                    output shouldContain ENTRY_URL
+                    output shouldContain "labels=[cdlib, oslc, test]"
+                    output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
+                    ret shouldBeExactly 0
                 }
-                output shouldContain "EntryUrl: "
-                output shouldContain "labels=[cdlib, oslc, test]"
-                output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
-                ret shouldBeExactly 0
+                
+                test("change create with report from gradle plugin") {
+                    val (ret, output) = withStandardOutput {
+                        val args =
+                            "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcGradlePluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
+                        PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
+                    }
+                    output shouldContain ENTRY_URL
+                    output shouldContain "labels=[cdlib, oslc, test]"
+                    output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
+                    ret shouldBeExactly 0
+                }
+                
             }
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -29,198 +29,207 @@ import kotlin.time.toDuration
 @Tags("IntegrationTest")
 @MicronautTest
 class ChangeCloseIntegrationTest(
-    @Value("\${change-management-token}") val token: String,
+    @Value("${change-management-token}") val token: String,
     private val changeTestHelper: ChangeTestHelper,
     private val changeHandler: ChangeHandler,
-) : StringSpec() {
-
-    private val status = "SUCCESS"
-    private val commercialReference = "5296"
-    private lateinit var changeDetails: ChangeCommand.CreateCommand.ChangeDetails
-    override suspend fun beforeTest(testCase: TestCase) {
-        super.beforeTest(testCase)
-        changeDetails = changeTestHelper.changeDetailsWithDefaults()
-        changeHandler
-            .initialise(
-                "Bearer $token",
-                isTestFlag = true,
-                enforceFrozenZoneFlag = false,
-                performWebapprovalFlag = false,
-                performOslcFlag = false,
-                gitopsFlag = false,
-                skipApprovalWaitFlag = true
-            )
-            .findItSystem(commercialReference)
-    }
-
-    override fun listeners(): List<TestListener> = listOf(
-        getSystemEnvironmentTestListenerWithOverrides(mapOf("CDLIB_PM_GIT_ORIGIN" to UUID.randomUUID().toString()))
-    )
-
-    init {
-        "Closing change with commercial reference is a success" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                )
-            }
-
-            output shouldContain "Retrieving IT system information (commercial reference, ALM-ID, name, key)."
-            output shouldContain "Finding change to close for the current pipeline."
-            output shouldNotContain "Could not find change to close for the current pipeline."
-            output shouldContain "Found the following change to close: "
-            output shouldContain "Closing change"
-            output shouldNotContain "Could not transition to 'Under Review'."
-            output shouldContain "Transitioning to next change request phase."
-            output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
-            output shouldContain "Pushing following metric object:"
-            exitCode shouldBe 0
+    ) : StringSpec() {
+    
+        companion object {
+            private const val METRIC_OBJECT_MESSAGE = "Pushing following metric object:"
         }
-
-        "Close change request fails when no change was created" {
+    
+        private val status = "SUCCESS"
+        private val commercialReference = "5296"
+        private lateinit var changeDetails: ChangeCommand.CreateCommand.ChangeDetails
+        override suspend fun beforeTest(testCase: TestCase) {
+            super.beforeTest(testCase)
+            changeDetails = changeTestHelper.changeDetailsWithDefaults()
             changeHandler
-                .findExisting()
-                .closeExisting()
-            val (exitCode, closeOutput) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                .initialise(
+                    "Bearer $token",
+                    isTestFlag = true,
+                    enforceFrozenZoneFlag = false,
+                    performWebapprovalFlag = false,
+                    performOslcFlag = false,
+                    gitopsFlag = false,
+                    skipApprovalWaitFlag = true
                 )
-            }
-
-            closeOutput shouldContain "Could not find change to close for the current pipeline."
-            exitCode shouldBe -1
+                .findItSystem(commercialReference)
         }
-
-        "Close change request fails and prints warnings when multiple changes were created" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, closeOutput) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                )
-            }
-
-            closeOutput shouldContain "Found multiple changes for this pipeline, please close them manually using the links below: "
-            exitCode shouldBe -1
-        }
-
-        "Publishing metrics with invalid parameter status fails and prints warnings" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status Invalid".toArgsArray()
-                )
-            }
-
-            output shouldContain "Failed to parse Pipeline status"
-            output shouldNotContain "Failed to create metric object."
-            exitCode shouldBe -1
-            changeTestHelper.closeChangeRequest(token, commercialReference)
-        }
-
-        "Publishing metrics with status: SUCCESS is a success" {
-            changeHandler
-                .post(changeDetails)
-                .preauthorize()
-                .transition(OPEN_TO_IMPLEMENTATION)
-
-            val (exitCode, output) = withStandardOutput {
-                PicocliRunner.call(
-                    ChangeCommand.CloseCommand::class.java,
-                    *"--debug --test --jira-token $token --commercial-reference $commercialReference --status SUCCESS".toArgsArray()
-                )
-            }
-
-            output shouldNotContain "Failed to parse Pipeline status"
-            output shouldNotContain "Failed to create metric object."
-            output shouldContain "Pushing following metric object:"
-            exitCode shouldBe 0
-        }
-
-        "Change is not closed for failed status" {
-            listOf("FAILED", "FAILURE").forAll {
+    
+        override fun listeners(): List<TestListener> = listOf(
+            getSystemEnvironmentTestListenerWithOverrides(mapOf("CDLIB_PM_GIT_ORIGIN" to UUID.randomUUID().toString()))
+        )
+    
+        init {
+            "Closing change with commercial reference is a success" {
+                changeHandler
+                    .post(changeDetails)
+                    .preauthorize()
+                    .transition(OPEN_TO_IMPLEMENTATION)
+    
                 val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CloseCommand::class.java,
+                        *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                    )
+                }
+    
+                output shouldContain "Retrieving IT system information (commercial reference, ALM-ID, name, key)."
+                output shouldContain "Finding change to close for the current pipeline."
+                output shouldNotContain "Could not find change to close for the current pipeline."
+                output shouldContain "Found the following change to close: "
+                output shouldContain "Closing change"
+                output shouldNotContain "Could not transition to 'Under Review'."
+                output shouldContain "Transitioning to next change request phase."
+                output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
+                output shouldContain METRIC_OBJECT_MESSAGE
+                exitCode shouldBe 0
+            }
+    
+            "Close change request fails when no change was created" {
+                changeHandler
+                    .findExisting()
+                    .closeExisting()
+                val (exitCode, closeOutput) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CloseCommand::class.java,
+                        *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                    )
+                }
+    
+                closeOutput shouldContain "Could not find change to close for the current pipeline."
+                exitCode shouldBe -1
+            }
+    
+            "Close change request fails and prints warnings when multiple changes were created" {
+                changeHandler
+                    .post(changeDetails)
+                    .preauthorize()
+                    .transition(OPEN_TO_IMPLEMENTATION)
+                    .post(changeDetails)
+                    .preauthorize()
+                    .transition(OPEN_TO_IMPLEMENTATION)
+    
+                val (exitCode, closeOutput) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CloseCommand::class.java,
+                        *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                    )
+                }
+    
+                closeOutput shouldContain "Found multiple changes for this pipeline, please close them manually using the links below: "
+                exitCode shouldBe -1
+            }
+    
+            "Publishing metrics with invalid parameter status fails and prints warnings" {
+                changeHandler
+                    .post(changeDetails)
+                    .preauthorize()
+                    .transition(OPEN_TO_IMPLEMENTATION)
+    
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CloseCommand::class.java,
+                        *"--debug --test --jira-token $token --commercial-reference $commercialReference --status Invalid".toArgsArray()
+                    )
+                }
+    
+                output shouldContain "Failed to parse Pipeline status"
+                output shouldNotContain "Failed to create metric object."
+                exitCode shouldBe -1
+                changeTestHelper.closeChangeRequest(token, commercialReference)
+            }
+    
+            "Publishing metrics with status: SUCCESS is a success" {
+                changeHandler
+                    .post(changeDetails)
+                    .preauthorize()
+                    .transition(OPEN_TO_IMPLEMENTATION)
+    
+                val (exitCode, output) = withStandardOutput {
+                    PicocliRunner.call(
+                        ChangeCommand.CloseCommand::class.java,
+                        *"--debug --test --jira-token $token --commercial-reference $commercialReference --status SUCCESS".toArgsArray()
+                    )
+                }
+    
+                output shouldNotContain "Failed to parse Pipeline status"
+                output shouldNotContain "Failed to create metric object."
+                output shouldContain METRIC_OBJECT_MESSAGE
+                exitCode shouldBe 0
+            }
+    
+            "Change is not closed for failed status" {
+                listOf("FAILED", "FAILURE").forAll {
+                    val (exitCode, output) = withStandardOutput {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--test --jira-token $token --commercial-reference $commercialReference --status $it".toArgsArray()
+                        )
+                    }
+                    output shouldNotContain "Closing change"
+                    output shouldContain "not closing change request."
+                    output shouldContain METRIC_OBJECT_MESSAGE
+                    exitCode shouldBe 0
+    
+    
+                    changeHandler.findExisting().closeExisting()
+                    Thread.sleep(15.toDuration(DurationUnit.SECONDS).inWholeMilliseconds)
+                }
+            }
+    
+            "Closing change successfully publishes metrics via Jenkins" {
+                withEnvironment(
+                    "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                    OverrideMode.SetOrOverride
+                ) {
                     changeHandler
                         .post(changeDetails)
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $it".toArgsArray()
-                    )
+    
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                        )
+                    }
+    
+                    output shouldContain "http://integration-test-url.jenkuns.example.com"
+                    output shouldContain "Dashboard status code: 201"
+                    exitCode shouldBeExactly 0
                 }
-                output shouldNotContain "Closing change"
-                output shouldContain "not closing change request."
-                output shouldContain "Pushing following metric object:"
-                exitCode shouldBe 0
-
-
-                changeHandler.findExisting().closeExisting()
-                Thread.sleep(15.toDuration(DurationUnit.SECONDS).inWholeMilliseconds)
+            }
+    
+            "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
+                withEnvironment(
+                    "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                    OverrideMode.SetOrOverride
+                ) {
+                    changeHandler
+                        .post(changeDetails)
+                        .preauthorize()
+                        .transition(OPEN_TO_IMPLEMENTATION)
+    
+                    val (exitCode, output) = withStandardOutput {
+                        PicocliRunner.call(
+                            ChangeCommand.CloseCommand::class.java,
+                            *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
+                        )
+                    }
+    
+                    output shouldContain "http://integration-test-url.jenkuns.example.com"
+                    output shouldContain "Dashboard status code: 201"
+                    exitCode shouldBeExactly 0
+                }
             }
         }
-
-        "Closing change successfully publishes metrics via Jenkins" {
-            withEnvironment(
-                "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
-                }
-
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
-            withEnvironment(
-                "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
-                    )
-                }
-
-                output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
+    }
                 output shouldContain "INFRA"
                 exitCode shouldBeExactly 0
             }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -183,6 +183,10 @@ class ChangeCloseIntegrationTest(
                 }
             }
     
+            companion object {
+                const val DASHBOARD_STATUS_MESSAGE = "Dashboard status code: 201"
+            }
+            
             "Closing change successfully publishes metrics via Jenkins" {
                 withEnvironment(
                     "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -192,20 +196,20 @@ class ChangeCloseIntegrationTest(
                         .post(changeDetails)
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
-    
+            
                     val (exitCode, output) = withStandardOutput {
                         PicocliRunner.call(
                             ChangeCommand.CloseCommand::class.java,
                             *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                         )
                     }
-    
+            
                     output shouldContain "http://integration-test-url.jenkuns.example.com"
-                    output shouldContain "Dashboard status code: 201"
+                    output shouldContain DASHBOARD_STATUS_MESSAGE
                     exitCode shouldBeExactly 0
                 }
             }
-    
+            
             "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
                 withEnvironment(
                     "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -215,92 +219,92 @@ class ChangeCloseIntegrationTest(
                         .post(changeDetails)
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
-    
+            
                     val (exitCode, output) = withStandardOutput {
                         PicocliRunner.call(
                             ChangeCommand.CloseCommand::class.java,
                             *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
                         )
                     }
-    
+            
                     output shouldContain "http://integration-test-url.jenkuns.example.com"
-                    output shouldContain "Dashboard status code: 201"
+                    output shouldContain DASHBOARD_STATUS_MESSAGE
                     exitCode shouldBeExactly 0
                 }
             }
-        }
-    }
-                output shouldContain "INFRA"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully publishes metrics via AzureDevOps" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
-                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-
-                val (exitCode, output) = withStandardOutput {
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
+                    }
                 }
-
-                output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
-
-        "Closing change successfully when having a fuzzy matching job url" {
-            val rnd = UUID.randomUUID().toString().substringBefore("-")
-
-            withEnvironment(
-                "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
-                OverrideMode.SetOrOverride
-            ) {
-                changeHandler
-                    .post(changeDetails)
-                    .preauthorize()
-                    .transition(OPEN_TO_IMPLEMENTATION)
-            }
-
-            withEnvironment(
-                mapOf(
-                    "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
-                    "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
-                ),
-                OverrideMode.SetOrOverride
-            ) {
-
-                val (exitCode, output) = withStandardOutput {
-                    changeHandler
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                    PicocliRunner.call(
-                        ChangeCommand.CloseCommand::class.java,
-                        *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
-                    )
-                }
-
-                output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
-                output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
-                output shouldContain "Dashboard status code: 201"
-                exitCode shouldBeExactly 0
-            }
-        }
+                            output shouldContain "INFRA"
+                            exitCode shouldBeExactly 0
+                        }
+                    }
+            
+                    "Closing change successfully publishes metrics via AzureDevOps" {
+                        val rnd = UUID.randomUUID().toString().substringBefore("-")
+            
+                        withEnvironment(
+                            mapOf(
+                                "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
+                                "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature"
+                            ),
+                            OverrideMode.SetOrOverride
+                        ) {
+                            changeHandler
+                                .post(changeDetails)
+                                .preauthorize()
+                                .transition(OPEN_TO_IMPLEMENTATION)
+            
+                            val (exitCode, output) = withStandardOutput {
+                                PicocliRunner.call(
+                                    ChangeCommand.CloseCommand::class.java,
+                                    *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                                )
+                            }
+            
+                            output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
+                            output shouldContain DASHBOARD_STATUS_MESSAGE
+                            exitCode shouldBeExactly 0
+                        }
+                    }
+            
+                    "Closing change successfully when having a fuzzy matching job url" {
+                        val rnd = UUID.randomUUID().toString().substringBefore("-")
+            
+                        withEnvironment(
+                            "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
+                            OverrideMode.SetOrOverride
+                        ) {
+                            changeHandler
+                                .post(changeDetails)
+                                .preauthorize()
+                                .transition(OPEN_TO_IMPLEMENTATION)
+                        }
+            
+                        withEnvironment(
+                            mapOf(
+                                "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
+                                "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends"
+                            ),
+                            OverrideMode.SetOrOverride
+                        ) {
+            
+                            val (exitCode, output) = withStandardOutput {
+                                changeHandler
+                                    .post(changeDetails)
+                                    .preauthorize()
+                                    .transition(OPEN_TO_IMPLEMENTATION)
+                                PicocliRunner.call(
+                                    ChangeCommand.CloseCommand::class.java,
+                                    *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
+                                )
+                            }
+            
+                            output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
+                            output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
+                            output shouldContain DASHBOARD_STATUS_MESSAGE
+                            exitCode shouldBeExactly 0
+                        }
+                    }
 
         "Change close with custom comment is succesful and adds the comment." {
             val test = "test"

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -22,9 +22,38 @@ import java.lang.reflect.Method
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 @MicronautTest
+package de.deutschepost.sdm.cdlib.change.changemanagement
+
+import de.deutschepost.sdm.cdlib.change.ChangeCommand
+import de.deutschepost.sdm.cdlib.change.metrics.model.Deployment
+import getSystemEnvironmentTestListenerWithOverrides
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import toArgsArray
+import withErrorOutput
+import withStandardOutput
+import java.lang.reflect.Method
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
+@MicronautTest
 class ChangeCreateCommandTest(
     @Value("\${change-management-token}") val token: String
 ) : StringSpec() {
+
+    companion object {
+        const val ILLEGAL_ARGUMENT_EXCEPTION_MSG = "java.lang.IllegalArgumentException"
+    }
+
     override fun listeners(): List<TestListener> {
         return listOf(
             getSystemEnvironmentTestListenerWithOverrides()
@@ -71,7 +100,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MSG
         }
 
         "Command fails if oslc but no distribution was passed" {
@@ -82,7 +111,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MSG
         }
 
         "Command doesn't fail if no-oslc and no distribution was passed" {
@@ -93,7 +122,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MSG
             output shouldContain "Verifying reports..."
         }
 
@@ -111,3 +140,4 @@ class ChangeCreateCommandTest(
         }
     }
 }
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
@@ -47,331 +47,149 @@ class ChangeCreateIntegrationTest(
     private val changeHandler: ChangeHandler
 ) : FunSpec() {
 
-    private val commercialReference = "5296"
-    private lateinit var changeDetails: ChangeCommand.CreateCommand.ChangeDetails
-    override suspend fun beforeTest(testCase: TestCase) {
-        super.beforeTest(testCase)
-        changeDetails = changeTestHelper.changeDetailsWithDefaults()
-        changeHandler
-            .initialise(
-                "Bearer $token",
-                isTestFlag = true,
-                enforceFrozenZoneFlag = false,
-                performWebapprovalFlag = false,
-                performOslcFlag = false,
-                gitopsFlag = false,
-                skipApprovalWaitFlag = true
-            )
-            .findItSystem(commercialReference)
-    }
-
-    override fun listeners(): List<TestListener> {
-        return listOf(
-            getSystemEnvironmentTestListenerWithOverrides()
-        )
-    }
-
-    init {
-        test("testing unsupported CDLib version preventing preauthorization") {
-            ApplicationContext.run(
-                Environment.CLI, Environment.TEST, "ver02"
-            ).use { ctx ->
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        ctx,
-                        *"change create --test --skip-approval-wait --jira-token $token --no-oslc --no-webapproval --no-tqs --commercial-reference $commercialReference".toArgsArray()
-                    )
-                }
-                output shouldContain "CDLib version 0.2.0-INTEGRATION-TEST is not supported anymore. Please update to a newer version. Pre-authorization is not possible."
-                output shouldContain "A new version of CDLib is available"
-
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Could not find changes to close nor resume for the current pipeline"
-                output shouldContain "Posting change request"
-                output shouldContain "Determining whether change can be preauthorized."
-                output shouldContain "  CDLib version is supported: false\n" +
-                    "  Impact Class: ${NONE.name}\n" +
-                    "  Business Criticality: ${OPERATIONAL.name}\n" +
-                    "  Determined change type --> MINOR"
-                output shouldContain "Updating change request type: MINOR"
-                output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
-
-            }
-            changeTestHelper.closeChangeRequest(
-                token,
-                commercialReference
+    package de.deutschepost.sdm.cdlib.change.changemanagement
+    
+    import de.deutschepost.sdm.cdlib.CdlibCommand
+    import de.deutschepost.sdm.cdlib.change.ChangeCommand
+    import de.deutschepost.sdm.cdlib.change.changemanagement.api.ChangeHandler
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ApprovalStatus
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.Category.HOUSEKEEPING
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangePhaseId.OPEN_TO_IMPLEMENTATION
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangeStatus.AWAITING_IMPLEMENTATION
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangeStatus.WAITING_FOR_APPROVAL
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ChangeType.MAJOR
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.Criticality.OPERATIONAL
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.FieldDefaults.APPROVAL_CHECK_TIMEOUT_IN_MINUTES
+    import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ImpactClass.NONE
+    import getSystemEnvironmentTestListenerWithOverrides
+    import io.kotest.core.annotation.RequiresTag
+    import io.kotest.core.annotation.Tags
+    import io.kotest.core.listeners.TestListener
+    import io.kotest.core.spec.Spec
+    import io.kotest.core.spec.style.FunSpec
+    import io.kotest.core.test.TestCase
+    import io.kotest.extensions.system.OverrideMode
+    import io.kotest.extensions.system.withEnvironment
+    import io.kotest.matchers.shouldBe
+    import io.kotest.matchers.string.shouldContain
+    import io.kotest.matchers.string.shouldNotContain
+    import io.micronaut.configuration.picocli.PicocliRunner
+    import io.micronaut.context.ApplicationContext
+    import io.micronaut.context.annotation.Value
+    import io.micronaut.context.env.Environment
+    import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+    import io.mockk.unmockkAll
+    import toArgsArray
+    import withErrorOutput
+    import withMockedVersionInfo
+    import withStandardOutput
+    import java.time.ZonedDateTime
+    import java.time.format.DateTimeFormatter
+    import java.time.temporal.ChronoUnit
+    
+    @RequiresTag("IntegrationTest")
+    @Tags("IntegrationTest")
+    @MicronautTest
+    class ChangeCreateIntegrationTest(
+        @Value("\${change-management-token}") val token: String,
+        private val changeTestHelper: ChangeTestHelper,
+        private val changeHandler: ChangeHandler
+    ) : FunSpec() {
+    
+        private val commercialReference = "5296"
+        private lateinit var changeDetails: ChangeCommand.CreateCommand.ChangeDetails
+    
+        companion object {
+            private const val CHECK_STATUS_MESSAGE = "Checking change request status for approval every "
+        }
+    
+        override suspend fun beforeTest(testCase: TestCase) {
+            super.beforeTest(testCase)
+            changeDetails = changeTestHelper.changeDetailsWithDefaults()
+            changeHandler
+                .initialise(
+                    "Bearer $token",
+                    isTestFlag = true,
+                    enforceFrozenZoneFlag = false,
+                    performWebapprovalFlag = false,
+                    performOslcFlag = false,
+                    gitopsFlag = false,
+                    skipApprovalWaitFlag = true
+                )
+                .findItSystem(commercialReference)
+        }
+    
+        override fun listeners(): List<TestListener> {
+            return listOf(
+                getSystemEnvironmentTestListenerWithOverrides()
             )
         }
-
-        withMockedVersionInfo(changeHandler) {
-            test("Creating change via full change command fails given an invalid commercial reference") {
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference DI-123456".toArgsArray()
-                    )
-                }
-                output shouldContain "Failed to get commercial reference: DI-123456"
-            }
-
-            test("Change created with wrong parameters and --trace option extends logging") {
-                val (_, output) = withStandardOutput {
-                    val args: Array<String> =
-                        "change create --skip-approval-wait --jira-token wrong --no-oslc --no-webapproval --no-tqs --debug --trace --commercial-reference $commercialReference --test".toArgsArray()
-                    PicocliRunner.run(CdlibCommand::class.java, *args)
-                }
-
-                output shouldContain "TRACE"
-            }
-
-            test("Change create command with no open changes for the current pipeline continues successfully with appropriate log") {
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
-                    )
-                }
-
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Could not find changes to close nor resume for the current pipeline"
-                output shouldContain "Posting change request"
-                output shouldContain "Determining whether change can be preauthorized."
-                output shouldContain "  Impact Class: ${NONE.name}\n" +
-                    "  Business Criticality: ${OPERATIONAL.name}\n" +
-                    "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
-                output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
-                output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-
-
-
-                changeTestHelper.closeChangeRequest(token, commercialReference)
-            }
-
-            context("Change create command with custom details...") {
-                test("...and wrong category fails.") {
-                    val (_, output) = withErrorOutput {
-                        val toArgsArray = """change create
-                        | --category=wrongCategory
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
-                            .toArgsArray()
+    
+        init {
+            test("testing unsupported CDLib version preventing preauthorization") {
+                ApplicationContext.run(
+                    Environment.CLI, Environment.TEST, "ver02"
+                ).use { ctx ->
+                    val (_, output) = withStandardOutput {
                         PicocliRunner.run(
                             CdlibCommand::class.java,
-                            *toArgsArray
+                            ctx,
+                            *"change create --test --skip-approval-wait --jira-token $token --no-oslc --no-webapproval --no-tqs --commercial-reference $commercialReference".toArgsArray()
                         )
                     }
-                    output shouldContain "Invalid value for option '--category': expected one of [ROLLOUT, NO_ROLLOUT, AUTHORIZATIONS, DATA_MAINTENANCE, TECHNICAL_REQUIREMENTS, LEGAL_OR_CONTRACTUAL_REQUIREMENTS, HOUSEKEEPING, CAPACITY_ADJUSTMENTS, SECURITY, TROUBLESHOOTING, OTHER] (case-sensitive) but was 'wrongCategory'"
-                }
-
-                test("...and wrong impactClass fails.") {
-                    val (_, output) = withErrorOutput {
-                        val toArgsArray = """change create
-                        | --impact-class=wrongImpactClass
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
-                            .toArgsArray()
-                        PicocliRunner.run(
-                            CdlibCommand::class.java,
-                            *toArgsArray
-                        )
-                    }
-
-                    output shouldContain "Invalid value for option '--impact-class': expected one of [CRITICAL, HIGH, LOW, MEDIUM, NONE] (case-sensitive) but was 'wrongImpactClass'"
-                }
-
-                test("...is successful with appropriate log and custom comment.") {
-                    val test = "test"
-                    val toArgsArray = """change create
-                        | --category $HOUSEKEEPING
-                        | --summary $test
-                        | --description $test
-                        | --impact-class $NONE
-                        | --impact $test
-                        | --target $test
-                        | --fallback $test
-                        | --implementation-risk $test
-                        | --omission-risk $test
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
-                        .toArgsArray()
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *toArgsArray
-                    )
-
-                    val change = changeHandler
-                        .findExisting()
-                        .findResumable()
-                        .getChange()
-
-                    change.category shouldBe HOUSEKEEPING
-                    change.summary shouldBe test
-                    change.description shouldBe test
-                    change.impactClass shouldBe NONE
-                    change.impact shouldBe test
-                    change.target shouldBe test
-                    change.fallback shouldBe test
-                    change.implementationRisk shouldBe test
-                    change.omissionRisk shouldBe test
-
-                    changeHandler.closeExisting()
-                }
-            }
-
-            test("Change create command with resume flag and changes open for the current pipeline closes all but the latest one and resumes that one successfully") {
-                withEnvironment(
-                    "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
-                    OverrideMode.SetOrOverride
-                ) {
-                    val changeDetails = changeTestHelper.changeDetailsWithDefaults()
-                    changeHandler
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                }
-
-                val (_, output) = withStandardOutput {
-                    withEnvironment(
-                        "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                        OverrideMode.SetOrOverride
-                    ) {
-                        PicocliRunner.run(
-                            CdlibCommand::class.java,
-                            *"change create --resume true --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
-                        )
-                    }
-                }
-
-                output shouldContain "Starting Change Management process."
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Closing change:"
-                output shouldContain "Adding abort comment to change..."
-                output shouldContain "Resuming change: "
-                output shouldContain "Adding resume comment to change..."
-                output shouldContain "Adding new job url to change description..."
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-                output shouldNotContain "Posting change request: "
-                output shouldNotContain "Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes."
-
-
-                changeTestHelper.closeChangeRequest(token, commercialReference)
-            }
-
-            test("Change create command with open changes that are awaiting implementation transitions them to 're-plan', cancels and then closes them") {
-
-                withEnvironment(
-                    "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
-                    OverrideMode.SetOrOverride
-                ) {
-                    changeHandler
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                        .post(changeDetails)
-                        .preauthorize()
-                        .transition(OPEN_TO_IMPLEMENTATION)
-                }
-
-                val (_, output) = withStandardOutput {
-                    withEnvironment(
-                        "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
-                        OverrideMode.SetOrOverride
-                    ) {
-                        PicocliRunner.run(
-                            CdlibCommand::class.java,
-                            *"change create --test --skip-approval-wait --debug --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
-                        )
-                    }
-                }
-
-                output shouldContain "Retrieving IT system information"
-                output shouldContain "Searching existing changes for the current pipeline"
-                output shouldContain "Closing change:"
-                output shouldContain "Rescheduling..."
-                output shouldContain "Cancelling..."
-                output shouldContain "Closing..."
-                output shouldContain "Adding abort comment to change..."
-                output shouldContain "Posting change request"
-                output shouldContain "Determining whether change can be preauthorized."
-                output shouldContain "  Impact Class: ${NONE.name}\n" +
-                    "  Business Criticality: ${OPERATIONAL.name}\n" +
-                    "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
-                output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
-                output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
-                output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-                output shouldNotContain "Could not find changes to close nor resume for the current pipeline"
-
-                changeTestHelper.closeChangeRequest(token, commercialReference)
-            }
-
-            context("Change create command during frozen zone") {
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *"change create --test --skip-approval-wait --start=2023-01-01T00:00:00+01:00 --no-oslc --no-webapproval --no-tqs --enforce-frozen-zone --jira-token $token --commercial-reference $commercialReference".toArgsArray()
-                    )
-                }
-
-                test("...creates a change and progresses it regularly") {
+                    output shouldContain "CDLib version 0.2.0-INTEGRATION-TEST is not supported anymore. Please update to a newer version. Pre-authorization is not possible."
+                    output shouldContain "A new version of CDLib is available"
+    
                     output shouldContain "Retrieving IT system information"
                     output shouldContain "Searching existing changes for the current pipeline"
+                    output shouldContain "Could not find changes to close nor resume for the current pipeline"
                     output shouldContain "Posting change request"
-                }
-
-                test("...ignores custom change window.") {
-                    output shouldContain "Frozen zone active: Ignoring set custom change window."
-                }
-
-                test("...recognises frozen zone") {
                     output shouldContain "Determining whether change can be preauthorized."
-                    output shouldContain "  Impact Class: ${NONE.name}\n" +
+                    output shouldContain "  CDLib version is supported: false\n" +
+                        "  Impact Class: ${NONE.name}\n" +
                         "  Business Criticality: ${OPERATIONAL.name}\n" +
-                        "  Special conditions:\n" +
-                        "    Frozen Zone (i.e. Starkverkehr) is active from "
-                }
-
-                test("...updates change type to major") {
-                    output shouldContain "  Determined change type --> ${MAJOR.name}"
-                    output shouldContain "Updating change request type: ${MAJOR.name}"
-                }
-
-                test("...and does not preauthorize nor approve it") {
+                        "  Determined change type --> MINOR"
+                    output shouldContain "Updating change request type: MINOR"
                     output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
+                    output shouldContain CHECK_STATUS_MESSAGE
                     output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
-                    output shouldNotContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-                    output shouldNotContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
+    
                 }
-
-                changeTestHelper.closeChangeRequest(token, commercialReference)
+                changeTestHelper.closeChangeRequest(
+                    token,
+                    commercialReference
+                )
             }
-
-            context("Change create with custom change window...") {
-                val now = ZonedDateTime.now()
-                val (_, output) = withStandardOutput {
-                    PicocliRunner.run(
-                        CdlibCommand::class.java,
-                        *("change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token " +
-                            "--commercial-reference $commercialReference " +
-                            "--start ${now.toIso()} " +
-                            "--end ${now.plusDays(2).toIso()}").toArgsArray(),
-                    )
+    
+            withMockedVersionInfo(changeHandler) {
+                test("Creating change via full change command fails given an invalid commercial reference") {
+                    val (_, output) = withStandardOutput {
+                        PicocliRunner.run(
+                            CdlibCommand::class.java,
+                            *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference DI-123456".toArgsArray()
+                        )
+                    }
+                    output shouldContain "Failed to get commercial reference: DI-123456"
                 }
-
-                test("...creates a change and progresses it regularly") {
-
+    
+                test("Change created with wrong parameters and --trace option extends logging") {
+                    val (_, output) = withStandardOutput {
+                        val args: Array<String> =
+                            "change create --skip-approval-wait --jira-token wrong --no-oslc --no-webapproval --no-tqs --debug --trace --commercial-reference $commercialReference --test".toArgsArray()
+                        PicocliRunner.run(CdlibCommand::class.java, *args)
+                    }
+    
+                    output shouldContain "TRACE"
+                }
+    
+                test("Change create command with no open changes for the current pipeline continues successfully with appropriate log") {
+                    val (_, output) = withStandardOutput {
+                        PicocliRunner.run(
+                            CdlibCommand::class.java,
+                            *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
+                        )
+                    }
+    
                     output shouldContain "Retrieving IT system information"
                     output shouldContain "Searching existing changes for the current pipeline"
                     output shouldContain "Could not find changes to close nor resume for the current pipeline"
@@ -382,9 +200,273 @@ class ChangeCreateIntegrationTest(
                         "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
                     output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                     output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                    output shouldContain "Checking change request status for approval every "
+                    output shouldContain CHECK_STATUS_MESSAGE
                     output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+    
+    
+                    changeTestHelper.closeChangeRequest(token, commercialReference)
                 }
+    
+                context("Change create command with custom details...") {
+                    test("...and wrong category fails.") {
+                        val (_, output) = withErrorOutput {
+                            val toArgsArray = """change create
+                            | --category=wrongCategory
+                            | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                            | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                                .toArgsArray()
+                            PicocliRunner.run(
+                                CdlibCommand::class.java,
+                                *toArgsArray
+                            )
+                        }
+                        output shouldContain "Invalid value for option '--category': expected one of [ROLLOUT, NO_ROLLOUT, AUTHORIZATIONS, DATA_MAINTENANCE, TECHNICAL_REQUIREMENTS, LEGAL_OR_CONTRACTUAL_REQUIREMENTS, HOUSEKEEPING, CAPACITY_ADJUSTMENTS, SECURITY, TROUBLESHOOTING, OTHER] (case-sensitive) but was 'wrongCategory'"
+                    }
+    
+                    test("...and wrong impactClass fails.") {
+                        val (_, output) = withErrorOutput {
+                            val toArgsArray = """change create
+                            | --impact-class=wrongImpactClass
+                            | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                            | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                                .toArgsArray()
+                            PicocliRunner.run(
+                                CdlibCommand::class.java,
+                                *toArgsArray
+                            )
+                        }
+    
+                        output shouldContain "Invalid value for option '--impact-class': expected one of [CRITICAL, HIGH, LOW, MEDIUM, NONE] (case-sensitive) but was 'wrongImpactClass'"
+                    }
+    
+                    test("...is successful with appropriate log and custom comment.") {
+                        val test = "test"
+                        val toArgsArray = """change create
+                            | --category $HOUSEKEEPING
+                            | --summary $test
+                            | --description $test
+                            | --impact-class $NONE
+                            | --impact $test
+                            | --target $test
+                            | --fallback $test
+                            | --implementation-risk $test
+                            | --omission-risk $test
+                            | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                            | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                            .toArgsArray()
+                        PicocliRunner.run(
+                            CdlibCommand::class.java,
+                            *toArgsArray
+                        )
+    
+                        val change = changeHandler
+                            .findExisting()
+                            .findResumable()
+                            .getChange()
+    
+                        change.category shouldBe HOUSEKEEPING
+                        change.summary shouldBe test
+                        change.description shouldBe test
+                        change.impactClass shouldBe NONE
+                        change.impact shouldBe test
+                        change.target shouldBe test
+                        change.fallback shouldBe test
+                        change.implementationRisk shouldBe test
+                        change.omissionRisk shouldBe test
+    
+                        changeHandler.closeExisting()
+                    }
+                }
+    
+                test("Change create command with resume flag and changes open for the current pipeline closes all but the latest one and resumes that one successfully") {
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        val changeDetails = changeTestHelper.changeDetailsWithDefaults()
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                    }
+    
+                    val (_, output) = withStandardOutput {
+                        withEnvironment(
+                            "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                            OverrideMode.SetOrOverride
+                        ) {
+                            PicocliRunner.run(
+                                CdlibCommand::class.java,
+                                *"change create --resume true --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
+                            )
+                        }
+                    }
+    
+                    output shouldContain "Starting Change Management process."
+                    output shouldContain "Retrieving IT system information"
+                    output shouldContain "Searching existing changes for the current pipeline"
+                    output shouldContain "Closing change:"
+                    output shouldContain "Adding abort comment to change..."
+                    output shouldContain "Resuming change: "
+                    output shouldContain "Adding resume comment to change..."
+                    output shouldContain "Adding new job url to change description..."
+                    output shouldContain CHECK_STATUS_MESSAGE
+                    output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                    output shouldNotContain "Posting change request: "
+                    output shouldNotContain "Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes."
+    
+    
+                    changeTestHelper.closeChangeRequest(token, commercialReference)
+                }
+    
+                test("Change create command with open changes that are awaiting implementation transitions them to 're-plan', cancels and then closes them") {
+    
+                    withEnvironment(
+                        "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
+                        OverrideMode.SetOrOverride
+                    ) {
+                        changeHandler
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                            .post(changeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+                    }
+    
+                    val (_, output) = withStandardOutput {
+                        withEnvironment(
+                            "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
+                            OverrideMode.SetOrOverride
+                        ) {
+                            PicocliRunner.run(
+                                CdlibCommand::class.java,
+                                *"change create --test --skip-approval-wait --debug --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
+                            )
+                        }
+                    }
+    
+                    output shouldContain "Retrieving IT system information"
+                    output shouldContain "Searching existing changes for the current pipeline"
+                    output shouldContain "Closing change:"
+                    output shouldContain "Rescheduling..."
+                    output shouldContain "Cancelling..."
+                    output shouldContain "Closing..."
+                    output shouldContain "Adding abort comment to change..."
+                    output shouldContain "Posting change request"
+                    output shouldContain "Determining whether change can be preauthorized."
+                    output shouldContain "  Impact Class: ${NONE.name}\n" +
+                        "  Business Criticality: ${OPERATIONAL.name}\n" +
+                        "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
+                    output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
+                    output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
+                    output shouldContain CHECK_STATUS_MESSAGE
+                    output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                    output shouldNotContain "Could not find changes to close nor resume for the current pipeline"
+    
+                    changeTestHelper.closeChangeRequest(token, commercialReference)
+                }
+    
+                context("Change create command during frozen zone") {
+                    val (_, output) = withStandardOutput {
+                        PicocliRunner.run(
+                            CdlibCommand::class.java,
+                            *"change create --test --skip-approval-wait --start=2023-01-01T00:00:00+01:00 --no-oslc --no-webapproval --no-tqs --enforce-frozen-zone --jira-token $token --commercial-reference $commercialReference".toArgsArray()
+                        )
+                    }
+    
+                    test("...creates a change and progresses it regularly") {
+                        output shouldContain "Retrieving IT system information"
+                        output shouldContain "Searching existing changes for the current pipeline"
+                        output shouldContain "Posting change request"
+                    }
+    
+                    test("...ignores custom change window.") {
+                        output shouldContain "Frozen zone active: Ignoring set custom change window."
+                    }
+    
+                    test("...recognises frozen zone") {
+                        output shouldContain "Determining whether change can be preauthorized."
+                        output shouldContain "  Impact Class: ${NONE.name}\n" +
+                            "  Business Criticality: ${OPERATIONAL.name}\n" +
+                            "  Special conditions:\n" +
+                            "    Frozen Zone (i.e. Starkverkehr) is active from "
+                    }
+    
+                    test("...updates change type to major") {
+                        output shouldContain "  Determined change type --> ${MAJOR.name}"
+                        output shouldContain "Updating change request type: ${MAJOR.name}"
+                    }
+    
+                    test("...and does not preauthorize nor approve it") {
+                        output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
+                        output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
+                        output shouldNotContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                        output shouldNotContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
+                    }
+    
+                    changeTestHelper.closeChangeRequest(token, commercialReference)
+                }
+    
+                context("Change create with custom change window...") {
+                    val now = ZonedDateTime.now()
+                    val (_, output) = withStandardOutput {
+                        PicocliRunner.run(
+                            CdlibCommand::class.java,
+                            *("change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token " +
+                                "--commercial-reference $commercialReference " +
+                                "--start ${now.toIso()} " +
+                                "--end ${now.plusDays(2).toIso()}").toArgsArray()
+                        )
+                    }
+    
+                    test("...creates a change and progresses it regularly") {
+    
+                        output shouldContain "Retrieving IT system information"
+                        output shouldContain "Searching existing changes for the current pipeline"
+                        output shouldContain "Could not find changes to close nor resume for the current pipeline"
+                        output shouldContain "Posting change request"
+                        output shouldContain "Determining whether change can be preauthorized."
+                        output shouldContain "  Impact Class: ${NONE.name}\n" +
+                            "  Business Criticality: ${OPERATIONAL.name}\n" +
+                            "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
+                        output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
+                        output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
+                        output shouldContain CHECK_STATUS_MESSAGE
+                        output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
+                    }
+    
+                    test("...exits when change window is over on a resume run") {
+                        val expiredChangeDetails = changeTestHelper.changeDetailsWithDefaults()
+                        expiredChangeDetails.startOpt = now.minusHours(5)
+                        expiredChangeDetails.endOpt = now.minusHours(4)
+    
+                        changeHandler
+                            .post(expiredChangeDetails)
+                            .preauthorize()
+                            .transition(OPEN_TO_IMPLEMENTATION)
+    
+                        val (_, out) = withStandardOutput {
+                            withMockedVersionInfo(changeHandler) {
+                                PicocliRunner.run(
+                                    CdlibCommand::class.java,
+                                    *"change create --resume true --no-oslc --no-webapproval --no-tqs --commercial-reference $commercialReference --test --skip-approval-wait --jira-token $token".toArgsArray()
+                                )
+                            }
+                        }
+    
+                        out shouldNotContain "Frozen zone (i.e. Starkverkehr) in effect from"
+                        out shouldContain "Change window has expired ("
+                        out shouldContain "therefore cannot\nresume and closing this change, please create a new change by re-triggering this run.\nAborting pipeline..."
+    
+                    }
+                }
+            }
+        }
+    
 
                 test("...exits when change window is over on a resume run") {
                     val expiredChangeDetails = changeTestHelper.changeDetailsWithDefaults()

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -1,5 +1,6 @@
 package de.deutschepost.sdm.cdlib.change.changemanagement
 
+import de.deutschepost.sdm.cdlib.change.changemanagement.model.JiraConstants.ImpactClass.BUSINESS_KRITIKALITÄT
 import de.deutschepost.sdm.cdlib.change.changemanagement.api.ChangeManagementRepository
 import de.deutschepost.sdm.cdlib.change.changemanagement.api.JiraApiClient
 import de.deutschepost.sdm.cdlib.change.changemanagement.model.*
@@ -184,7 +185,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_KRITIKALITÄT,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -196,7 +197,7 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_KRITIKALITÄT,
                                                 6
                                             ),
                                             objectKey = "objectKey",
@@ -251,7 +252,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_KRITIKALITÄT,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -263,9 +264,9 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
-                                                6
-                                            ),
+                                                name = BUSINESS_KRITIKALITÄT,
+                                                                    6
+                                                                ),
                                             objectKey = "objectKey",
                                             label = "label"
                                         ),

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
@@ -31,12 +31,15 @@ class NameResolverAzureTest(
 ) : AnnotationSpec() {
     private val before = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toInstant()
 
+    companion object {
+        const val EXPECTED_APP_NAME = "ICTO-3339_SDM-phippyandfriends"
+    }
 
     override fun listeners() = listOf(
         SystemEnvironmentTestListener(
             mapOf(
                 "BUILD_BUILDID" to "12657",
-                "BUILD_DEFINITIONNAME" to "ICTO-3339_SDM-phippyandfriends",
+                "BUILD_DEFINITIONNAME" to EXPECTED_APP_NAME,
                 "BUILD_SOURCEBRANCHNAME" to "i593_test",
                 "SYSTEM_COLLECTIONURI" to "https://dev.azure.com/sw-zustellung-31b3183/",
                 "SYSTEM_TEAMPROJECT" to "ICTO-3339_SDM",
@@ -100,7 +103,7 @@ class NameResolverAzureTest(
 
     @Test
     fun testCreate_APP_NAME() {
-        resolver[Names.CDLIB_APP_NAME] shouldBeEqualComparingTo "ICTO-3339_SDM-phippyandfriends"
+        resolver[Names.CDLIB_APP_NAME] shouldBeEqualComparingTo EXPECTED_APP_NAME
     }
 
     @Test
@@ -184,8 +187,10 @@ class NameResolverAzureTest(
     @Test
     fun testCreate_RELEASE_NAME() {
         resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "_12657_a5c5bc3"
-        resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "ICTO-3339_SDM-phippyandfriends"
+        resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase EXPECTED_APP_NAME
     }
+}
+
 
     @Test
     fun testCreate_RELEASE_NAME_FORTIFY() {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -19,7 +19,32 @@ import withStandardOutput
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import de.deutschepost.sdm.cdlib.names.git.GitRepository
+import de.deutschepost.sdm.cdlib.names.git.GitRevision
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.SystemEnvironmentTestListener
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.mockk.every
+import io.mockk.mockkObject
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class NamesCommandAzureTest : AnnotationSpec() {
+
+    companion object {
+        private const val VSO_APP_NAME_CMD = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+    }
 
     override fun listeners() = listOf(
         SystemEnvironmentTestListener(
@@ -32,9 +57,8 @@ class NamesCommandAzureTest : AnnotationSpec() {
                 "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "",
                 "BUILD_SOURCEBRANCH" to "refs/heads/i593_test",
                 "SYSTEM_DEFINITIONID" to "101010",
-                // Explicit set / reset var. relevant for platform detection
                 "TF_BUILD" to "True",
-                "JENKINS_HOME" to "",
+                "JENKINS_HOME" to ""
             ), OverrideMode.SetOrOverride
         )
     )
@@ -61,7 +85,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
 
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase VSO_APP_NAME_CMD
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
@@ -85,7 +109,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             val args = "names create --from-release-name $releaseName".toArgsArray()
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase VSO_APP_NAME_CMD
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_VERSION;isOutput=true]20211203.1809.18"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_BUILD_NUMBER;isOutput=true]20210908.16"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
@@ -109,7 +133,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
         withEnvironment(
             mapOf(
                 "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "refs/heads/i593_test",
-                "BUILD_SOURCEBRANCHNAME" to "merge",
+                "BUILD_SOURCEBRANCHNAME" to "merge"
             ),
             OverrideMode.SetOrOverride
         ) {
@@ -118,7 +142,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+            output shouldContainIgnoringCase VSO_APP_NAME_CMD
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
@@ -127,3 +151,4 @@ class NamesCommandAzureTest : AnnotationSpec() {
 
     }
 }
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -11,6 +11,19 @@ import withStandardOutput
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.string.shouldContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class NamesCommandTest : DescribeSpec({
     describe("cdlib names") {
         describe("names -h") {
@@ -18,7 +31,7 @@ class NamesCommandTest : DescribeSpec({
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(HELP_DESCRIPTION) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }
@@ -29,7 +42,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(HELP_DESCRIPTION) {
                 output shouldContain "Create canonical set of standard names and IDs"
                 output shouldContain "Name of optional output file"
                 output shouldContain "Release name to use for derived name creation"
@@ -43,7 +56,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(HELP_DESCRIPTION) {
                 output shouldContain "Dumps the list of environment variables"
                 output shouldContain "Name of optional output file"
             }
@@ -61,4 +74,9 @@ class NamesCommandTest : DescribeSpec({
             }
         }
     }
-})
+}) {
+    companion object {
+        const val HELP_DESCRIPTION = "should display help"
+    }
+}
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -13,6 +13,10 @@ import io.mockk.mockkObject
 class RepositoryTest : AnnotationSpec() {
     private val currDir = System.getProperty("user.dir")
 
+    companion object {
+        private const val EMAIL_ADDRESS = "f.l@dhl.com"
+    }
+
     @BeforeAll
     fun initMocks() {
         mockkObject(GitRepository)
@@ -22,9 +26,9 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = EMAIL_ADDRESS,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = EMAIL_ADDRESS
         )
     }
 
@@ -35,9 +39,9 @@ class RepositoryTest : AnnotationSpec() {
         revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.authorEmail shouldBeEqualComparingTo EMAIL_ADDRESS
         revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.committerEmail shouldBeEqualComparingTo EMAIL_ADDRESS
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -18,9 +18,32 @@ import withStandardOutput
 @RequiresTag("IntegrationTest")
 @Tags("IntegrationTest")
 @MicronautTest
+package de.deutschepost.sdm.cdlib.release
+
+import de.deutschepost.sdm.cdlib.release.report.TestResultPrefixes
+import getSystemEnvironmentTestListenerWithOverrides
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("IntegrationTest")
+@Tags("IntegrationTest")
+@MicronautTest
 class ReportOslcGradlePluginIntegrationTest(
-    @Value("\${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
+    @Value("${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
 ) : FunSpec() {
+
+    companion object {
+        const val POLICY_PROFILE_DISTRIBUTION = "Policy Profile: Distribution"
+    }
 
     private val appName = "cli"
     private val releaseName = "Integration_result_0228"
@@ -68,7 +91,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldNotContain "Unapproved Licenses Count: 0"
             }
 
@@ -79,7 +102,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 0"
             }
 
@@ -90,7 +113,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
             }
@@ -102,7 +125,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
             }
@@ -121,3 +144,4 @@ class ReportOslcGradlePluginIntegrationTest(
     }
 
 }
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -40,6 +40,10 @@ class ReportOslcNPMPluginIntegrationTest(
         )
     )
 
+    companion object {
+        const val UPLOADED_ARTIFACT_TEXT = "Uploaded Artifact:"
+    }
+
     init {
         context("Check OSLC-Plugin report and upload") {
             test("Check OSLC-Plugin report locally") {
@@ -58,7 +62,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT_TEXT
             }
             // TODO: Delete after sundown
             test("Upload OSLC-Plugin report to LCM artifactory") {
@@ -68,7 +72,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT_TEXT
             }
 
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
@@ -88,9 +92,10 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldNotContain "Uploaded Artifact:"
+                output shouldNotContain UPLOADED_ARTIFACT_TEXT
             }
         }
     }
 
 }
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -22,8 +22,32 @@ import java.io.File
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.release.report
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import de.deutschepost.sdm.cdlib.release.report.external.FnciTestResult
+import de.deutschepost.sdm.cdlib.release.report.external.fnci.FnciInventoryItem
+import de.deutschepost.sdm.cdlib.release.report.external.fnci.FnciProjectInfo
+import de.deutschepost.sdm.cdlib.release.report.external.fnci.FnciProjectInfoWrapper
+import de.deutschepost.sdm.cdlib.release.report.external.from
+import de.deutschepost.sdm.cdlib.release.report.internal.OslcComplianceStatus
+import de.deutschepost.sdm.cdlib.release.report.internal.OslcTestResult
+import de.deutschepost.sdm.cdlib.utils.defaultObjectMapper
+import de.deutschepost.sdm.cdlib.utils.permissiveObjectMapper
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.maps.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+import java.io.File
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class FnciReportTest : FunSpec({
-    val projectPath = "src/test/resources/fnci/fnci-project.json"
+    val projectPath = PROJECT_JSON_PATH
     val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
     context("Project Info") {
         test("Parses projectInfo correctly") {
@@ -52,7 +76,7 @@ class FnciReportTest : FunSpec({
         val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
         test("Generate OslcTestResult") {
             val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
+                OslcTestResult.from(FnciTestResult(projectInfo, inventory), PROJECT_JSON_PATH)
             report.complianceStatus shouldBe OslcComplianceStatus.RED
             report.unapprovedItems.shouldNotBeEmpty()
             defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
@@ -61,7 +85,7 @@ class FnciReportTest : FunSpec({
         test("Only approved is compliant") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                PROJECT_JSON_PATH
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()
@@ -71,9 +95,13 @@ class FnciReportTest : FunSpec({
         test("Canonical file name should depend on project, not files") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                PROJECT_JSON_PATH
             )
             report.canonicalFilename shouldEndWith "${report.projectName}.json"
         }
     }
-})
+}) {
+    companion object {
+        const val PROJECT_JSON_PATH = "src/test/resources/fnci/fnci-project.json"
+    }
+}

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -46,65 +46,72 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
-                        row("0.0.0", 0, VersionSpecification(0, 0, 0)),
-                        row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
-                        row("1.2.3", 0, VersionSpecification(1, 2, 3)),
-                        row("1.2.3.4", 0, VersionSpecification(1, 2, 3)),
-                        row("1", 0, VersionSpecification(1, 0, 0)),
-                        row("6.6", 6, VersionSpecification(6, 6, 6)),
-                    )
-                ) { input: String, default: Int, expected: VersionSpecification ->
-                    VersionSpecification.fromString(input, default) shouldBe expected
-                }
-            }
-
-            test("Testing invalid input strings") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Input String", "Default Value"),
-                        row("a.b.c", 0),
-                        row("error", 0),
-                        row("3,2,5", 0),
-                    )
-                ) { input: String, default: Int ->
-                    shouldThrow<NumberFormatException> { VersionSpecification.fromString(input, default) }
-                }
-            }
-
-            test("Testing valid ranged input strings") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
-                        row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
-                        row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
-                        row(
-                            "1.2.3-",
-                            VersionSpecification(1, 2, 3),
-                            VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
-                        ),
-                        row("1-1.5", VersionSpecification(1, 0, 0), VersionSpecification(1, 5, Int.MAX_VALUE)),
-                        row(
-                            "-",
-                            VersionSpecification(0, 0, 0),
-                            VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
-                        ),
-                        row(
-                            "",
-                            VersionSpecification(0, 0, 0),
-                            VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
-                        ),
-                        row("11.12.13", VersionSpecification(11, 12, 13), VersionSpecification(11, 12, 13)),
-                    )
-                ) { input: String, min: VersionSpecification, max: VersionSpecification ->
-                    VersionSpecification.rangeFromString(input) shouldBe min..max
-                }
-            }
-
-            test("Testing invalid ranged input strings") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Input String"),
+                        headers(INPUT_STRING, "Default Value", "Expected"),
+                                                row("0.0.0", 0, VersionSpecification(0, 0, 0)),
+                                                row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
+                                                row("1.2.3", 0, VersionSpecification(1, 2, 3)),
+                                                row("1.2.3.4", 0, VersionSpecification(1, 2, 3)),
+                                                row("1", 0, VersionSpecification(1, 0, 0)),
+                                                row("6.6", 6, VersionSpecification(6, 6, 6))
+                                            )
+                                        ) { input: String, default: Int, expected: VersionSpecification ->
+                                            VersionSpecification.fromString(input, default) shouldBe expected
+                                        }
+                                    }
+                        
+                                    test("Testing invalid input strings") {
+                                        io.kotest.data.forAll(
+                                            table(
+                                                headers(INPUT_STRING, "Default Value"),
+                                                row("a.b.c", 0),
+                                                row("error", 0),
+                                                row("3,2,5", 0)
+                                            )
+                                        ) { input: String, default: Int ->
+                                            shouldThrow<NumberFormatException> { VersionSpecification.fromString(input, default) }
+                                        }
+                                    }
+                        
+                                    test("Testing valid ranged input strings") {
+                                        io.kotest.data.forAll(
+                                            table(
+                                                headers(INPUT_STRING, "ExpectedMin", "ExpectedMax"),
+                                                row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
+                                                row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
+                                                row(
+                                                    "1.2.3-",
+                                                    VersionSpecification(1, 2, 3),
+                                                    VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
+                                                ),
+                                                row("1-1.5", VersionSpecification(1, 0, 0), VersionSpecification(1, 5, Int.MAX_VALUE)),
+                                                row(
+                                                    "-",
+                                                    VersionSpecification(0, 0, 0),
+                                                    VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
+                                                ),
+                                                row(
+                                                    "",
+                                                    VersionSpecification(0, 0, 0),
+                                                    VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
+                                                ),
+                                                row("11.12.13", VersionSpecification(11, 12, 13), VersionSpecification(11, 12, 13))
+                                            )
+                                        ) { input: String, min: VersionSpecification, max: VersionSpecification ->
+                                            VersionSpecification.rangeFromString(input) shouldBe min..max
+                                        }
+                                    }
+                        
+                                    test("Testing invalid ranged input strings") {
+                                        io.kotest.data.forAll(
+                                            table(
+                                                headers(INPUT_STRING),
+                                                row("1.2.3-11.12.13-1.2.3"),
+                                                row("1-1-1")
+                                            )
+                                        ) { input: String ->
+                                            shouldThrow<RuntimeException> { VersionSpecification.rangeFromString(input) }
+                                        }
+                                    }
                         row("1.2.3-11.12.13-1.2.3"),
                         row("1-1-1"),
                     )

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
@@ -38,7 +38,10 @@ class OslcComplianceCheckerTest : FunSpec() {
             )
         )
     )
-    private val licenseMozillaName = "Mozilla Public License 2.0"
+    companion object {
+        const val MOZILLA_PUBLIC_LICENSE = "Mozilla Public License 2.0"
+    }
+    private val licenseMozillaName = MOZILLA_PUBLIC_LICENSE
     private val depWithCDDL = OslcDependencyLicenseEntry(
         dependencyName = "test.should.fail:cddl",
         dependencyVersion = "",
@@ -75,7 +78,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         )
     )
     private val licenseLGPL3Name = "GNU Lesser General Public License 3.0"
-
+    
     private val depWithGPLCE = OslcDependencyLicenseEntry(
         dependencyName = "test.should.succeed:GPL_CE",
         dependencyVersion = "",
@@ -112,8 +115,8 @@ class OslcComplianceCheckerTest : FunSpec() {
         )
     )
     private val licenseAlladinName = "Alladin Free Public License 9"
-
-
+    
+    
     init {
         context("findMatchingLicense Tests") {
             test("Table Test for selected Licenses with distribution") {
@@ -126,21 +129,21 @@ class OslcComplianceCheckerTest : FunSpec() {
                     row(depWithAPL2, null),
                     row(depWithAladin, licenseAlladinName),
                 ) { dep: OslcDependencyLicenseEntry, licenseName: String? ->
-
+    
                     val output = OslcComplianceChecker.findAllMatchingLicenses(dep, true)
                     println("Given: ${dep.licenses.joinToString { "[${it.license} - ${it.url}]" }}")
                     println("Got: ${output.joinToString { "[${it.license}]" }}")
-
+    
                     if (licenseName != null) {
                         output.isNotEmpty() shouldBe true
                         output.any { it.license == licenseName } shouldBe true
                     } else {
                         output.isEmpty() shouldBe true
                     }
-
+    
                 }
             }
-
+    
             test("Table Test for selected Licenses with non-distribution") {
                 io.kotest.data.forAll(
                     row(depWithMozilla, null),
@@ -154,21 +157,21 @@ class OslcComplianceCheckerTest : FunSpec() {
                     val output = OslcComplianceChecker.findAllMatchingLicenses(dep, false)
                     println("Given: ${dep.licenses.joinToString { "[${it.license} - ${it.url}]" }}")
                     println("Got: ${output.joinToString { "[${it.license}]" }}")
-
+    
                     if (licenseName != null) {
                         output.isNotEmpty() shouldBe true
                         output.any { it.license == licenseName } shouldBe true
                     } else {
                         output.isEmpty() shouldBe true
                     }
-
+    
                 }
             }
         }
         context("Check Reading bundleFile and disallowedLicenses file") {
             test("Distribution File") {
                 val definitions = OslcComplianceChecker.buildDefinitions(disallowedLicensesDistributionPath)
-
+    
                 val expectedLicenses = mapOf(
                     "Alladin Free Public License 9" to 5,
                     "Academic Free License 3.0" to 3,
@@ -181,7 +184,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     "GNU Lesser General Public License 2.1" to 9,
                     "GNU General Public License 2.0" to 4,
                     "GNU General Public License 3.0" to 4,
-                    "Mozilla Public License 2.0" to 5
+                    MOZILLA_PUBLIC_LICENSE to 5
                 )
                 val notExpectedLicenses = listOf(
                     "Apache License 2.0",
@@ -212,10 +215,10 @@ class OslcComplianceCheckerTest : FunSpec() {
                     }
                 }
             }
-
+    
             test("Non-Distribution File") {
                 val definitions = OslcComplianceChecker.buildDefinitions(disallowedLicensesNonDistributionPath)
-
+    
                 val expectedLicenses = mapOf(
                     "Alladin Free Public License 9" to 5,
                     "Academic Free License 3.0" to 3,
@@ -259,7 +262,7 @@ class OslcComplianceCheckerTest : FunSpec() {
             dependencyLicenseEntries.forEach { entry ->
                 println("entry: ${entry.dependencyName} - ${entry.licenses.joinToString { "${it.license}|${it.url}" }}")
             }
-
+    
             test("With Distribution") {
                 val output = OslcComplianceChecker.getIncomliantLicenses(dependencyLicenseEntries, true)
                 output.forEach { mapEntry ->
@@ -282,7 +285,33 @@ class OslcComplianceCheckerTest : FunSpec() {
                 val epl2 = output.entries.firstOrNull { it.key.license == "Eclipse Public License 2.0" }
                 epl2 shouldNotBe null
                 epl2?.value?.size shouldBe 1
-                val mpl2 = output.entries.firstOrNull { it.key.license == "Mozilla Public License 2.0" }
+                val mpl2 = output.entries.firstOrNull { it.key.license == MOZILLA_PUBLIC_LICENSE }
+                mpl2 shouldNotBe null
+                mpl2?.value?.size shouldBe 1
+                val unknown = output.entries.firstOrNull { it.key.license == "UNKNOWN" }
+                unknown shouldNotBe null
+                unknown?.value?.size shouldBe 1
+    
+            }
+            test("With Non-Distribution") {
+                val output = OslcComplianceChecker.getIncomliantLicenses(dependencyLicenseEntries, false)
+                output.forEach { mapEntry ->
+                    println("Found disallowed entry for license: ${mapEntry.key.license} got modules: [${mapEntry.value.joinToString { "${it.dependencyName}," }}]")
+                }
+                output.size shouldBe 1
+                val unknown = output.entries.firstOrNull { it.key.license == "UNKNOWN" }
+                unknown shouldNotBe null
+                unknown?.value?.size shouldBe 1
+    
+            }
+            test("Get All Licenses Test") {
+                val output = OslcComplianceChecker.getAllLicensesNames(dependencyLicenseEntries, false)
+                output.size shouldBe 76
+                output.contains("NULL") shouldBe false
+    
+            }
+        }
+    }
                 mpl2 shouldNotBe null
                 mpl2?.value?.size shouldBe 1
                 val unknown = output.entries.firstOrNull { it.key.license == "UNKNOWN" }


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: aaad402

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
