### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -248,115 +248,120 @@ class ChangeHandler(
     }
 
     fun preauthorize(): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
-        logger.info { "Determining whether change can be preauthorized." }
-        val changeType = determineChangeType()
-        logTypeResults(changeType)
-        change = change.updateType(changeType)
-
-        runCatching {
-            logger.info { "Updating change request type: ${change.type?.name}" }
-            changeManagementRepository.updateChange(change, auth)
-        }.getOrElse {
-            logger.error { "Could not update change request type. \nError: ${it.message}" }
+        companion object {
+            const val MISSING_CHANGE_INFO_MSG = "Missing required change information."
         }
-        return this
-    }
-
-    fun resume(): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        logger.info { "Resuming change: ${change.self}" }
-        logger.info { "Adding resume comment to change..." }
-
-        changeManagementRepository.addComment(
-            change.id,
-            "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
-            auth
-        )
-
-        logger.info { "Adding new job url to change description..." }
-        change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
-
-        changeManagementRepository.updateChange(change, auth)
-
-        return this
-    }
-
-    fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        runCatching {
-            logger.info { "Transitioning change request phase: ${phase.name}" }
-            changeManagementRepository.transitionChangePhase(
-                changeId = change.id,
-                phaseId = phase.value,
-                auth = auth
+        
+        fun preauthorize(): ChangeHandler {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO_MSG }
+            logger.info { "Determining whether change can be preauthorized." }
+            val changeType = determineChangeType()
+            logTypeResults(changeType)
+            change = change.updateType(changeType)
+        
+            runCatching {
+                logger.info { "Updating change request type: ${change.type?.name}" }
+                changeManagementRepository.updateChange(change, auth)
+            }.getOrElse {
+                logger.error { "Could not update change request type. \nError: ${it.message}" }
+            }
+            return this
+        }
+        
+        fun resume(): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO_MSG }
+        
+            logger.info { "Resuming change: ${change.self}" }
+            logger.info { "Adding resume comment to change..." }
+        
+            changeManagementRepository.addComment(
+                change.id,
+                "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
+                auth
             )
-        }.onFailure {
-            it.klogSelf(logger)
-        }.getOrThrow()
-
-        return this
-    }
-
-    fun monitor(approvalCheckInterval: Int): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
-        logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
-
-        for (i in 1..numberOfApprovalChecks) {
-            val changeRequest = runCatching {
-                changeManagementRepository.getChangeRequest(change.id, auth)
+        
+            logger.info { "Adding new job url to change description..." }
+            change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
+        
+            changeManagementRepository.updateChange(change, auth)
+        
+            return this
+        }
+        
+        fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO_MSG }
+        
+            runCatching {
+                logger.info { "Transitioning change request phase: ${phase.name}" }
+                changeManagementRepository.transitionChangePhase(
+                    changeId = change.id,
+                    phaseId = phase.value,
+                    auth = auth
+                )
             }.onFailure {
                 it.klogSelf(logger)
             }.getOrThrow()
-
-            logChangeRequestStatus(changeRequest)
-
-            if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
-                return this
+        
+            return this
+        }
+        
+        fun monitor(approvalCheckInterval: Int): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO_MSG }
+        
+            val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
+            logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
+        
+            for (i in 1..numberOfApprovalChecks) {
+                val changeRequest = runCatching {
+                    changeManagementRepository.getChangeRequest(change.id, auth)
+                }.onFailure {
+                    it.klogSelf(logger)
+                }.getOrThrow()
+        
+                logChangeRequestStatus(changeRequest)
+        
+                if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
+                    return this
+                }
+                waitBeforeNextCheck(approvalCheckInterval)
             }
-            waitBeforeNextCheck(approvalCheckInterval)
+            throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
         }
-        throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
-    }
-
-    fun getItSystem(): ItSystem {
-        require(::itSystem.isInitialized) {
-            "Missing required IT system information."
+        
+        fun getItSystem(): ItSystem {
+            require(::itSystem.isInitialized) {
+                "Missing required IT system information."
+            }
+            return itSystem
         }
-        return itSystem
-    }
-
-    fun getChange(): Change {
-        require(::change.isInitialized) { "Missing required change information." }
-        return change
-    }
-
-    fun comment(comment: String): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
-        if (comment.isNotEmpty()) {
-            logger.info { "Adding custom comment to change." }
-            changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
+        
+        fun getChange(): Change {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO_MSG }
+            return change
         }
-        return this
-    }
-
-    fun getComments(changeId: String): List<ChangeComment> {
-        return changeManagementRepository.getComments(changeId, auth)
-    }
-
-    fun getUrl(): String {
-        require(::change.isInitialized) { "Missing required change information." }
-        val url = change.self
-        requireNotNull(url)
-        return url
-    }
+        
+        fun comment(comment: String): ChangeHandler {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO_MSG }
+            if (comment.isNotEmpty()) {
+                logger.info { "Adding custom comment to change." }
+                changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
+            }
+            return this
+        }
+        
+        fun getComments(changeId: String): List<ChangeComment> {
+            return changeManagementRepository.getComments(changeId, auth)
+        }
+        
+        fun getUrl(): String {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO_MSG }
+            val url = change.self
+            requireNotNull(url)
+            return url
+        }
 
     private fun logChangeRequestStatus(changeRequest: Change) {
         requireNotNull(changeRequest.status) {

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -21,12 +21,11 @@ data class LicenseBlackListEntry(
 )
 
 object OslcComplianceChecker : KLogging() {
-
-    private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
-    private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+    object OslcComplianceChecker : KLogging() {
+        private const val RESOURCE_NOT_FOUND = "not found"
+        private val disallowedLicensesDistributionPath: String = javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: RESOURCE_NOT_FOUND
+        private val disallowedLicensesNonDistributionPath: String = javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: RESOURCE_NOT_FOUND
+        private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: RESOURCE_NOT_FOUND
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -3,17 +3,19 @@ package de.deutschepost.sdm.cdlib.utils
 import java.io.File
 import java.security.MessageDigest
 
+private const val SHA_256 = "SHA-256"
+
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -80,6 +80,7 @@ class ChangeOslcIntegrationTest(
 
     init {
         context("Creating oslc change is a success") {
+            val ENTRY_URL = "EntryUrl: "
             test("change create --oslc missing distribution") {
                 val (ret, output) = withStandardOutput {
                     val args =
@@ -89,37 +90,37 @@ class ChangeOslcIntegrationTest(
                 ret shouldBe -1
                 output shouldContain "IllegalArgumentException"
             }
-
+        
             test("change create with distribution") {
                 val (ret, output) = withStandardOutput {
                     val args =
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
             }
-
+        
             test("change create with report from maven plugin") {
                 val (ret, output) = withStandardOutput {
                     val args =
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0
             }
-
+        
             test("change create with report from gradle plugin") {
                 val (ret, output) = withStandardOutput {
                     val args =
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcGradlePluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -184,6 +184,10 @@ class ChangeCloseIntegrationTest(
     }
 
 
+        companion object {
+            const val DASHBOARD_STATUS = "Dashboard status code: 201"
+        }
+        
         "Closing change successfully publishes metrics via Jenkins" {
             withEnvironment(
                 "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -193,20 +197,20 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS
                 exitCode shouldBeExactly 0
             }
         }
-
+        
         "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
             withEnvironment(
                 "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -216,28 +220,28 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS
                 output shouldContain "INFRA"
                 exitCode shouldBeExactly 0
             }
         }
-
+        
         "Closing change successfully publishes metrics via AzureDevOps" {
             val rnd = UUID.randomUUID().toString().substringBefore("-")
-
+        
             withEnvironment(
                 mapOf(
                     "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
-                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
+                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature"
                 ),
                 OverrideMode.SetOrOverride
             ) {
@@ -245,23 +249,23 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS
                 exitCode shouldBeExactly 0
             }
         }
-
+        
         "Closing change successfully when having a fuzzy matching job url" {
             val rnd = UUID.randomUUID().toString().substringBefore("-")
-
+        
             withEnvironment(
                 "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
                 OverrideMode.SetOrOverride
@@ -271,15 +275,15 @@ class ChangeCloseIntegrationTest(
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
             }
-
+        
             withEnvironment(
                 mapOf(
                     "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
-                    "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
+                    "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends"
                 ),
                 OverrideMode.SetOrOverride
             ) {
-
+        
                 val (exitCode, output) = withStandardOutput {
                     changeHandler
                         .post(changeDetails)
@@ -290,12 +294,14 @@ class ChangeCloseIntegrationTest(
                         *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
                 output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS
                 exitCode shouldBeExactly 0
             }
+        }
+        
         }
 
         "Change close with custom comment is succesful and adds the comment." {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -33,6 +33,9 @@ class ChangeCloseIntegrationTest(
     private val changeTestHelper: ChangeTestHelper,
     private val changeHandler: ChangeHandler,
 ) : StringSpec() {
+    companion object {
+        const val PUSHING_METRIC_OBJECT = "Pushing following metric object:"
+    }
 
     private val status = "SUCCESS"
     private val commercialReference = "5296"
@@ -79,7 +82,7 @@ class ChangeCloseIntegrationTest(
             output shouldNotContain "Could not transition to 'Under Review'."
             output shouldContain "Transitioning to next change request phase."
             output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain PUSHING_METRIC_OBJECT
             exitCode shouldBe 0
         }
 
@@ -152,7 +155,7 @@ class ChangeCloseIntegrationTest(
 
             output shouldNotContain "Failed to parse Pipeline status"
             output shouldNotContain "Failed to create metric object."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain PUSHING_METRIC_OBJECT
             exitCode shouldBe 0
         }
 
@@ -170,7 +173,7 @@ class ChangeCloseIntegrationTest(
                 }
                 output shouldNotContain "Closing change"
                 output shouldContain "not closing change request."
-                output shouldContain "Pushing following metric object:"
+                output shouldContain PUSHING_METRIC_OBJECT
                 exitCode shouldBe 0
 
 
@@ -178,6 +181,8 @@ class ChangeCloseIntegrationTest(
                 Thread.sleep(15.toDuration(DurationUnit.SECONDS).inWholeMilliseconds)
             }
         }
+    }
+
 
         "Closing change successfully publishes metrics via Jenkins" {
             withEnvironment(

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -71,9 +71,9 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MSG
         }
-
+        
         "Command fails if oslc but no distribution was passed" {
             val (exitCode, output) = withStandardOutput {
                 PicocliRunner.call(
@@ -82,9 +82,9 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MSG
         }
-
+        
         "Command doesn't fail if no-oslc and no distribution was passed" {
             val (exitCode, output) = withStandardOutput {
                 PicocliRunner.call(
@@ -93,7 +93,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION_MSG
             output shouldContain "Verifying reports..."
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -184,88 +184,89 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
-                                                                    6
-                                                                ),
-                                                                objectKey = "objectKey",
-                                                                label = "label"
-                                                            ),
-                                                        )
-                                                    ),
-                                                    objectTypeAttributeId = itSystemAttributeId
-                                                )
-                                            ),
-                                            objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
-                                                6
-                                            ),
-                                            objectKey = "objectKey",
-                                            label = "label"
-                                        ),
-                                    )
-                                ),
-                                objectTypeAttributeId = itSystemAttributeId
-                            ),
-                            JiraAttribute(
-                                objectAttributeValues = listOf(
-                                    JiraObjectAttributeValue(
-                                        displayValue = almId,
-                                        searchValue = almId,
-                                        referencedObject = null,
-                                    )
-                                ),
-                                objectTypeAttributeId = almAttributeId
-                            ),
-                            JiraAttribute(
-                                objectAttributeValues = listOf(
-                                    JiraObjectAttributeValue(
-                                        displayValue = businessYear,
-                                        searchValue = businessYear,
-                                        referencedObject = null,
-                                    )
-                                ),
-                                objectTypeAttributeId = businessYearAttributeId
-                            )
-                        ),
-                        objectType = JiraObjectType(
-                            name = "name",
-                            6
-                        ),
-                        objectKey = commercialReference,
-                        label = "label"
-                    ),
-                    JiraObjectEntry(
-                        attributes = listOf(
-                            JiraAttribute(
-                                objectAttributeValues = listOf(
-                                    JiraObjectAttributeValue(
-                                        displayValue = itSystemName,
-                                        searchValue = itSystemKey,
-                                        referencedObject = JiraObjectEntry(
-                                            attributes = listOf(
-                                                JiraAttribute(
-                                                    objectAttributeValues = listOf(
-                                                        JiraObjectAttributeValue(
-                                                            displayValue = criticality,
-                                                            searchValue = criticality,
-                                                            referencedObject = JiraObjectEntry(
-                                                                attributes = listOf(),
-                                                                objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
-                                                                    6
-                                                                ),
-                                                                objectKey = "objectKey",
-                                                                label = "label"
-                                                            ),
-                                                        )
-                                                    ),
-                                                    objectTypeAttributeId = itSystemAttributeId
-                                                )
-                                            ),
-                                            objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
-                                                6
-                                            ),
+                                                                    private const val BUSINESS_KRITIKALITAET = "Business Kritikalität"
+                                                                                                                                        name = BUSINESS_KRITIKALITAET,
+                                                                                                                                        6
+                                                                                                                                    ),
+                                                                                                                                    objectKey = "objectKey",
+                                                                                                                                    label = "label"
+                                                                                                                                ),
+                                                                                                                            )
+                                                                                                                        ),
+                                                                                                                        objectTypeAttributeId = itSystemAttributeId
+                                                                                                                    )
+                                                                                                                ),
+                                                                                                                objectType = JiraObjectType(
+                                                                                                                    name = BUSINESS_KRITIKALITAET,
+                                                                                                                    6
+                                                                                                                ),
+                                                                                                                objectKey = "objectKey",
+                                                                                                                label = "label"
+                                                                                                            ),
+                                                                                                        )
+                                                                                                    ),
+                                                                                                    objectTypeAttributeId = itSystemAttributeId
+                                                                                                ),
+                                                                                                JiraAttribute(
+                                                                                                    objectAttributeValues = listOf(
+                                                                                                        JiraObjectAttributeValue(
+                                                                                                            displayValue = almId,
+                                                                                                            searchValue = almId,
+                                                                                                            referencedObject = null,
+                                                                                                        )
+                                                                                                    ),
+                                                                                                    objectTypeAttributeId = almAttributeId
+                                                                                                ),
+                                                                                                JiraAttribute(
+                                                                                                    objectAttributeValues = listOf(
+                                                                                                        JiraObjectAttributeValue(
+                                                                                                            displayValue = businessYear,
+                                                                                                            searchValue = businessYear,
+                                                                                                            referencedObject = null,
+                                                                                                        )
+                                                                                                    ),
+                                                                                                    objectTypeAttributeId = businessYearAttributeId
+                                                                                                )
+                                                                                            ),
+                                                                                            objectType = JiraObjectType(
+                                                                                                name = "name",
+                                                                                                6
+                                                                                            ),
+                                                                                            objectKey = commercialReference,
+                                                                                            label = "label"
+                                                                                        ),
+                                                                                        JiraObjectEntry(
+                                                                                            attributes = listOf(
+                                                                                                JiraAttribute(
+                                                                                                    objectAttributeValues = listOf(
+                                                                                                        JiraObjectAttributeValue(
+                                                                                                            displayValue = itSystemName,
+                                                                                                            searchValue = itSystemKey,
+                                                                                                            referencedObject = JiraObjectEntry(
+                                                                                                                attributes = listOf(
+                                                                                                                    JiraAttribute(
+                                                                                                                        objectAttributeValues = listOf(
+                                                                                                                            JiraObjectAttributeValue(
+                                                                                                                                displayValue = criticality,
+                                                                                                                                searchValue = criticality,
+                                                                                                                                referencedObject = JiraObjectEntry(
+                                                                                                                                    attributes = listOf(),
+                                                                                                                                    objectType = JiraObjectType(
+                                                                                                                                        name = BUSINESS_KRITIKALITAET,
+                                                                                                                                        6
+                                                                                                                                    ),
+                                                                                                                                    objectKey = "objectKey",
+                                                                                                                                    label = "label"
+                                                                                                                                ),
+                                                                                                                            )
+                                                                                                                        ),
+                                                                                                                        objectTypeAttributeId = itSystemAttributeId
+                                                                                                                    )
+                                                                                                                ),
+                                                                                                                objectType = JiraObjectType(
+                                                                                                                    name = BUSINESS_KRITIKALITAET,
+                                                                                                                    6
+                                                                                                                ),
                                             objectKey = "objectKey",
                                             label = "label"
                                         ),

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -19,7 +19,32 @@ import withStandardOutput
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import de.deutschepost.sdm.cdlib.names.git.GitRepository
+import de.deutschepost.sdm.cdlib.names.git.GitRevision
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.SystemEnvironmentTestListener
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.mockk.every
+import io.mockk.mockkObject
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class NamesCommandAzureTest : AnnotationSpec() {
+
+    companion object {
+        private const val VSO_APP_NAME = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+    }
 
     override fun listeners() = listOf(
         SystemEnvironmentTestListener(
@@ -61,7 +86,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
 
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase VSO_APP_NAME
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
@@ -85,7 +110,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             val args = "names create --from-release-name $releaseName".toArgsArray()
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase VSO_APP_NAME
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_VERSION;isOutput=true]20211203.1809.18"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_BUILD_NUMBER;isOutput=true]20210908.16"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
@@ -109,7 +134,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
         withEnvironment(
             mapOf(
                 "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "refs/heads/i593_test",
-                "BUILD_SOURCEBRANCHNAME" to "merge",
+                "BUILD_SOURCEBRANCHNAME" to "merge"
             ),
             OverrideMode.SetOrOverride
         ) {
@@ -118,7 +143,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+            output shouldContainIgnoringCase VSO_APP_NAME
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -11,6 +11,19 @@ import withStandardOutput
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.string.shouldContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class NamesCommandTest : DescribeSpec({
     describe("cdlib names") {
         describe("names -h") {
@@ -18,7 +31,7 @@ class NamesCommandTest : DescribeSpec({
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(NamesCommandTest.HELP_DISPLAY) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }
@@ -29,7 +42,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(NamesCommandTest.HELP_DISPLAY) {
                 output shouldContain "Create canonical set of standard names and IDs"
                 output shouldContain "Name of optional output file"
                 output shouldContain "Release name to use for derived name creation"
@@ -43,7 +56,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(NamesCommandTest.HELP_DISPLAY) {
                 output shouldContain "Dumps the list of environment variables"
                 output shouldContain "Name of optional output file"
             }
@@ -61,4 +74,8 @@ class NamesCommandTest : DescribeSpec({
             }
         }
     }
-})
+}) {
+    companion object {
+        const val HELP_DISPLAY = "should display help"
+    }
+}

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockkObject
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class RepositoryTest : AnnotationSpec() {
+    companion object { const val DHL_EMAIL = "f.l@dhl.com" }
     private val currDir = System.getProperty("user.dir")
 
     @BeforeAll
@@ -22,9 +23,9 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = DHL_EMAIL,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = DHL_EMAIL
         )
     }
 
@@ -35,9 +36,9 @@ class RepositoryTest : AnnotationSpec() {
         revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.authorEmail shouldBeEqualComparingTo DHL_EMAIL
         revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.committerEmail shouldBeEqualComparingTo DHL_EMAIL
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -32,6 +32,10 @@ class ReportOslcGradlePluginIntegrationTest(
     private val acceptedListFileWrongLicense = "src/test/resources/oslc/acceptedList-wrongLicense.json"
     private val acceptedListFileWrongVersion = "src/test/resources/oslc/acceptedList-wrongVersion.json"
 
+    companion object {
+        const val POLICY_PROFILE_DISTRIBUTION = "Policy Profile: Distribution"
+    }
+
     override fun listeners() = listOf(
         getSystemEnvironmentTestListenerWithOverrides(
             mapOf(
@@ -68,7 +72,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain ReportOslcGradlePluginIntegrationTest.POLICY_PROFILE_DISTRIBUTION
                 output shouldNotContain "Unapproved Licenses Count: 0"
             }
 
@@ -79,7 +83,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain ReportOslcGradlePluginIntegrationTest.POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 0"
             }
 
@@ -90,7 +94,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain ReportOslcGradlePluginIntegrationTest.POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
             }
@@ -102,7 +106,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain ReportOslcGradlePluginIntegrationTest.POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
             }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -18,9 +18,28 @@ import withStandardOutput
 @RequiresTag("IntegrationTest")
 @Tags("IntegrationTest")
 @MicronautTest
+package de.deutschepost.sdm.cdlib.release
+
+import de.deutschepost.sdm.cdlib.release.report.TestResultPrefixes
+import getSystemEnvironmentTestListenerWithOverrides
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("IntegrationTest")
+@Tags("IntegrationTest")
+@MicronautTest
 class ReportOslcNPMPluginIntegrationTest(
-    @Value("\${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
-    @Value("\${artifactory-azure-identity-token}") val artifactoryLCMIdentityToken: String,
+    @Value("${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
+    @Value("${artifactory-azure-identity-token}") val artifactoryLCMIdentityToken: String,
 ) : FunSpec() {
 
     private val appName = "cli"
@@ -40,6 +59,10 @@ class ReportOslcNPMPluginIntegrationTest(
         )
     )
 
+    companion object {
+        const val UPLOADED_ARTIFACT = "Uploaded Artifact:"
+    }
+
     init {
         context("Check OSLC-Plugin report and upload") {
             test("Check OSLC-Plugin report locally") {
@@ -58,7 +81,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT
             }
             // TODO: Delete after sundown
             test("Upload OSLC-Plugin report to LCM artifactory") {
@@ -68,7 +91,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT
             }
 
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
@@ -88,9 +111,10 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldNotContain "Uploaded Artifact:"
+                output shouldNotContain UPLOADED_ARTIFACT
             }
         }
     }
 
 }
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -52,7 +52,7 @@ class FnciReportTest : FunSpec({
         val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
         test("Generate OslcTestResult") {
             val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
+                OslcTestResult.from(FnciTestResult(projectInfo, inventory), projectPath)
             report.complianceStatus shouldBe OslcComplianceStatus.RED
             report.unapprovedItems.shouldNotBeEmpty()
             defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
@@ -61,7 +61,7 @@ class FnciReportTest : FunSpec({
         test("Only approved is compliant") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                projectPath
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()
@@ -71,7 +71,7 @@ class FnciReportTest : FunSpec({
         test("Canonical file name should depend on project, not files") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                projectPath
             )
             report.canonicalFilename shouldEndWith "${report.projectName}.json"
         }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -46,7 +46,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
+                        headers(HEADER_INPUT_STRING, "Default Value", "Expected"),
                         row("0.0.0", 0, VersionSpecification(0, 0, 0)),
                         row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
                         row("1.2.3", 0, VersionSpecification(1, 2, 3)),
@@ -62,7 +62,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing invalid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value"),
+                        headers(HEADER_INPUT_STRING, "Default Value"),
                         row("a.b.c", 0),
                         row("error", 0),
                         row("3,2,5", 0),
@@ -75,7 +75,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
+                        headers(HEADER_INPUT_STRING, "ExpectedMin", "ExpectedMax"),
                         row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
                         row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
                         row(
@@ -104,7 +104,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing invalid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String"),
+                        headers(HEADER_INPUT_STRING)
                         row("1.2.3-11.12.13-1.2.3"),
                         row("1-1-1"),
                     )

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
@@ -18,7 +18,31 @@ import java.io.File
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.release.report
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import de.deutschepost.sdm.cdlib.release.report.external.OslcGradlePluginTestResult
+import de.deutschepost.sdm.cdlib.release.report.external.from
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcComplianceChecker
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcDependencyLicenseEntry
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcLicenseDefinition
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcLicenseEntry
+import de.deutschepost.sdm.cdlib.utils.defaultObjectMapper
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.io.File
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class OslcComplianceCheckerTest : FunSpec() {
+
+    companion object {
+        const val MOZILLA_PUBLIC_LICENSE = "Mozilla Public License 2.0"
+    }
 
     private val disallowedLicensesDistributionPath: String =
         "src/main/resources/oslc/disallowedLicensesDistribution.json"
@@ -34,11 +58,11 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "MPL 2.0",
-                url = "https://www.mozilla.org/en-US/MPL/2.0/",
+                url = "https://www.mozilla.org/en-US/MPL/2.0/"
             )
         )
     )
-    private val licenseMozillaName = "Mozilla Public License 2.0"
+    private val licenseMozillaName = MOZILLA_PUBLIC_LICENSE
     private val depWithCDDL = OslcDependencyLicenseEntry(
         dependencyName = "test.should.fail:cddl",
         dependencyVersion = "",
@@ -46,7 +70,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0",
-                url = "https://oss.oracle.com/licenses/CDDL",
+                url = "https://oss.oracle.com/licenses/CDDL"
             )
         )
     )
@@ -58,7 +82,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1",
-                url = "https://www.gnu.org/licenses/lgpl-2.1",
+                url = "https://www.gnu.org/licenses/lgpl-2.1"
             )
         )
     )
@@ -70,7 +94,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU LESSER GENERAL PUBLIC LICENSE, Version 3.0",
-                url = "https://www.gnu.org/licenses/lgpl-3.0",
+                url = "https://www.gnu.org/licenses/lgpl-3.0"
             )
         )
     )
@@ -83,7 +107,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception",
-                url = "https://openjdk.java.net/legal/gplv2+ce.html",
+                url = "https://openjdk.java.net/legal/gplv2+ce.html"
             )
         )
     )
@@ -95,7 +119,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "Apache License 2.0",
-                url = "https://www.apache.org/licenses/LICENSE-2.0",
+                url = "https://www.apache.org/licenses/LICENSE-2.0"
             )
         )
     )
@@ -107,7 +131,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "Aladin Free Public License",
-                url = "http://www.artifex.com/downloads/doc/Public.htm",
+                url = "http://www.artifex.com/downloads/doc/Public.htm"
             )
         )
     )
@@ -124,7 +148,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     row(depWithLGPL3, licenseLGPL3Name),
                     row(depWithGPLCE, null),
                     row(depWithAPL2, null),
-                    row(depWithAladin, licenseAlladinName),
+                    row(depWithAladin, licenseAlladinName)
                 ) { dep: OslcDependencyLicenseEntry, licenseName: String? ->
 
                     val output = OslcComplianceChecker.findAllMatchingLicenses(dep, true)
@@ -149,7 +173,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     row(depWithLGPL3, null),
                     row(depWithGPLCE, null),
                     row(depWithAPL2, null),
-                    row(depWithAladin, licenseAlladinName),
+                    row(depWithAladin, licenseAlladinName)
                 ) { dep: OslcDependencyLicenseEntry, licenseName: String? ->
                     val output = OslcComplianceChecker.findAllMatchingLicenses(dep, false)
                     println("Given: ${dep.licenses.joinToString { "[${it.license} - ${it.url}]" }}")
@@ -181,7 +205,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     "GNU Lesser General Public License 2.1" to 9,
                     "GNU General Public License 2.0" to 4,
                     "GNU General Public License 3.0" to 4,
-                    "Mozilla Public License 2.0" to 5
+                    MOZILLA_PUBLIC_LICENSE to 5
                 )
                 val notExpectedLicenses = listOf(
                     "Apache License 2.0",
@@ -218,7 +242,7 @@ class OslcComplianceCheckerTest : FunSpec() {
 
                 val expectedLicenses = mapOf(
                     "Alladin Free Public License 9" to 5,
-                    "Academic Free License 3.0" to 3,
+                    "Academic Free License 3.0" to 3
                 )
                 val notExpectedLicenses = listOf(
                     "Apache License 2.0",
@@ -235,7 +259,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     "GNU Lesser General Public License 2.1",
                     "GNU General Public License 2.0",
                     "GNU General Public License 3.0",
-                    "Mozilla Public License 2.0"
+                    MOZILLA_PUBLIC_LICENSE
                 )
                 printDefinitions(definitions)
                 expectedLicenses.forEach { (license: String, numberOfAliases: Int) ->
@@ -282,7 +306,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                 val epl2 = output.entries.firstOrNull { it.key.license == "Eclipse Public License 2.0" }
                 epl2 shouldNotBe null
                 epl2?.value?.size shouldBe 1
-                val mpl2 = output.entries.firstOrNull { it.key.license == "Mozilla Public License 2.0" }
+                val mpl2 = output.entries.firstOrNull { it.key.license == MOZILLA_PUBLIC_LICENSE }
                 mpl2 shouldNotBe null
                 mpl2?.value?.size shouldBe 1
                 val unknown = output.entries.firstOrNull { it.key.license == "UNKNOWN" }
@@ -310,6 +334,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         }
     }
 }
+
 
 private fun printDefinitions(definitions: List<OslcLicenseDefinition>) {
     definitions.forEach {


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: d31d67b

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
