### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
@@ -248,115 +248,121 @@ class ChangeHandler(
     }
 
     fun preauthorize(): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
-        logger.info { "Determining whether change can be preauthorized." }
-        val changeType = determineChangeType()
-        logTypeResults(changeType)
-        change = change.updateType(changeType)
-
-        runCatching {
-            logger.info { "Updating change request type: ${change.type?.name}" }
-            changeManagementRepository.updateChange(change, auth)
-        }.getOrElse {
-            logger.error { "Could not update change request type. \nError: ${it.message}" }
+        companion object {
+            const val MISSING_CHANGE_INFO = "Missing required change information."
         }
-        return this
-    }
-
-    fun resume(): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        logger.info { "Resuming change: ${change.self}" }
-        logger.info { "Adding resume comment to change..." }
-
-        changeManagementRepository.addComment(
-            change.id,
-            "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
-            auth
-        )
-
-        logger.info { "Adding new job url to change description..." }
-        change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
-
-        changeManagementRepository.updateChange(change, auth)
-
-        return this
-    }
-
-    fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        runCatching {
-            logger.info { "Transitioning change request phase: ${phase.name}" }
-            changeManagementRepository.transitionChangePhase(
-                changeId = change.id,
-                phaseId = phase.value,
-                auth = auth
+        
+        fun preauthorize(): ChangeHandler {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+            logger.info { "Determining whether change can be preauthorized." }
+            val changeType = determineChangeType()
+            logTypeResults(changeType)
+            change = change.updateType(changeType)
+        
+            runCatching {
+                logger.info { "Updating change request type: ${change.type?.name}" }
+                changeManagementRepository.updateChange(change, auth)
+            }.getOrElse {
+                logger.error { "Could not update change request type. \nError: ${it.message}" }
+            }
+            return this
+        }
+        
+        fun resume(): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+        
+            logger.info { "Resuming change: ${change.self}" }
+            logger.info { "Adding resume comment to change..." }
+        
+            changeManagementRepository.addComment(
+                change.id,
+                "Change wird mit anderer Pipeline (${resolveEnvByName(Names.CDLIB_JOB_URL)}) fortgesetzt.",
+                auth
             )
-        }.onFailure {
-            it.klogSelf(logger)
-        }.getOrThrow()
-
-        return this
-    }
-
-    fun monitor(approvalCheckInterval: Int): ChangeHandler {
-        require(::auth.isInitialized) { "Missing required authentication token." }
-        require(::change.isInitialized) { "Missing required change information." }
-
-        val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
-        logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
-
-        for (i in 1..numberOfApprovalChecks) {
-            val changeRequest = runCatching {
-                changeManagementRepository.getChangeRequest(change.id, auth)
+        
+            logger.info { "Adding new job url to change description..." }
+            change = change.updateDescription(change.description + "\n" + resolveEnvByName(Names.CDLIB_JOB_URL))
+        
+            changeManagementRepository.updateChange(change, auth)
+        
+            return this
+        }
+        
+        fun transition(phase: JiraConstants.ChangePhaseId): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+        
+            runCatching {
+                logger.info { "Transitioning change request phase: ${phase.name}" }
+                changeManagementRepository.transitionChangePhase(
+                    changeId = change.id,
+                    phaseId = phase.value,
+                    auth = auth
+                )
             }.onFailure {
                 it.klogSelf(logger)
             }.getOrThrow()
-
-            logChangeRequestStatus(changeRequest)
-
-            if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
-                return this
+        
+            return this
+        }
+        
+        fun monitor(approvalCheckInterval: Int): ChangeHandler {
+            require(::auth.isInitialized) { "Missing required authentication token." }
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+        
+            val numberOfApprovalChecks = (APPROVAL_CHECK_TIMEOUT_IN_MINUTES / approvalCheckInterval)
+            logger.info { "Checking change request status for approval every ${approvalCheckInterval}m." }
+        
+            for (i in 1..numberOfApprovalChecks) {
+                val changeRequest = runCatching {
+                    changeManagementRepository.getChangeRequest(change.id, auth)
+                }.onFailure {
+                    it.klogSelf(logger)
+                }.getOrThrow()
+        
+                logChangeRequestStatus(changeRequest)
+        
+                if (changeRequest.status == ChangeStatus.AWAITING_IMPLEMENTATION) {
+                    return this
+                }
+                waitBeforeNextCheck(approvalCheckInterval)
             }
-            waitBeforeNextCheck(approvalCheckInterval)
+            throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
         }
-        throw Exception("Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes.")
-    }
-
-    fun getItSystem(): ItSystem {
-        require(::itSystem.isInitialized) {
-            "Missing required IT system information."
+        
+        fun getItSystem(): ItSystem {
+            require(::itSystem.isInitialized) {
+                "Missing required IT system information."
+            }
+            return itSystem
         }
-        return itSystem
-    }
-
-    fun getChange(): Change {
-        require(::change.isInitialized) { "Missing required change information." }
-        return change
-    }
-
-    fun comment(comment: String): ChangeHandler {
-        require(::change.isInitialized) { "Missing required change information." }
-        if (comment.isNotEmpty()) {
-            logger.info { "Adding custom comment to change." }
-            changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
+        
+        fun getChange(): Change {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+            return change
         }
-        return this
-    }
-
-    fun getComments(changeId: String): List<ChangeComment> {
-        return changeManagementRepository.getComments(changeId, auth)
-    }
-
-    fun getUrl(): String {
-        require(::change.isInitialized) { "Missing required change information." }
-        val url = change.self
-        requireNotNull(url)
-        return url
-    }
+        
+        fun comment(comment: String): ChangeHandler {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+            if (comment.isNotEmpty()) {
+                logger.info { "Adding custom comment to change." }
+                changeManagementRepository.addComment(id = change.id, comment = comment, auth = auth)
+            }
+            return this
+        }
+        
+        fun getComments(changeId: String): List<ChangeComment> {
+            return changeManagementRepository.getComments(changeId, auth)
+        }
+        
+        fun getUrl(): String {
+            require(::change.isInitialized) { MISSING_CHANGE_INFO }
+            val url = change.self
+            requireNotNull(url)
+            return url
+        }
+        
 
     private fun logChangeRequestStatus(changeRequest: Change) {
         requireNotNull(changeRequest.status) {

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -41,7 +41,7 @@ open class SharepointClient(private val user: String, private val password: Stri
 
     private fun getDigest(): String? {
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/contextinfo").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", JSON_CONTENT_TYPE)
         }
         return client.execute(httpPost).use { response ->
             logger.info { "Getting Sharepoint Digest: ${response.statusLine}" }
@@ -56,15 +56,15 @@ open class SharepointClient(private val user: String, private val password: Stri
             }
         }
     }
-
+    
     fun addEntryProd(approvalsListItem: SharepointApprovalsListItem) =
         addEntry(approvalsListItem, ISHARE_PROD_LIST)
-
+    
     fun addEntryTest(approvalsListItem: SharepointApprovalsListItem): Webapproval {
         val approvalsListItemTest = approvalsListItem.copy(metadata = SharepointApprovalsListItem.Metadata.TEST)
         return addEntry(approvalsListItemTest, ISHARE_TEST_LIST)
     }
-
+    
     private fun addEntry(
         approvalsListItem: SharepointApprovalsListItem,
         listName: String,
@@ -72,31 +72,31 @@ open class SharepointClient(private val user: String, private val password: Stri
         val digest =
             checkNotNull(getDigest()) {
                 """
-                Failed to get digest for Record.
-                This is eiter a connection issue or a credentials issue. You can check this with following command:
-                curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: application/json;odata=verbose\"""".trimIndent()
+                    Failed to get digest for Record.
+                    This is eiter a connection issue or a credentials issue. You can check this with following command:
+                    curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: $JSON_CONTENT_TYPE\""".trimIndent()
             }
-
+    
         val webapprovalWithoutURL =
             checkNotNull(verifyAndGenerateWebapproval(approvalsListItem.applicationId, listName == ISHARE_TEST_LIST)) {
                 "Failed validating approval documents."
             }
-
+    
         val httpEntity = EntityBuilder.create().apply {
             text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
         }.build()
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", JSON_CONTENT_TYPE)
             addHeader("X-RequestDigest", digest)
-            addHeader("Content-Type", "application/json;odata=verbose")
+            addHeader("Content-Type", JSON_CONTENT_TYPE)
             entity = httpEntity
         }
-
+    
         val webapprovalUrl = client.execute(httpPost).use { response ->
             logger.info { "Adding Record: ${response.statusLine}" }
             val content = EntityUtils.toString(response.entity)
             logger.debug { content }
-
+    
             if (response.statusLine.statusCode != HttpStatus.SC_CREATED) {
                 logger.error { content }
                 throw IllegalStateException("Failed to create Record.")
@@ -109,8 +109,7 @@ open class SharepointClient(private val user: String, private val password: Stri
         logger.info { "EntryUrl: $webapprovalUrl" }
         return webapprovalWithoutURL.copy(url = webapprovalUrl)
     }
-
-
+    
     fun verifyAndGenerateWebapproval(applicationId: Int, isTest: Boolean): Webapproval? {
         val sharepointApprovalConfiguration = getSharepointApprovalConfigurations().findById(applicationId)
         logger.info { "Getting approvalStatus for ApplicationID $applicationId" }
@@ -118,12 +117,12 @@ open class SharepointClient(private val user: String, private val password: Stri
             sharepointApprovalConfiguration?.status == null -> {
                 logger.error {
                     """Cannot find valid pipeline configuration entry for ApplicationID $applicationId
-                    Did you already request one: $ISHARE_WEBAPPROVAL_BASE_URL/Lists/Pipeline%20Approval%20Configuration/AllItems.aspx
-                    """.trimIndent()
+                        Did you already request one: $ISHARE_WEBAPPROVAL_BASE_URL/Lists/Pipeline%20Approval%20Configuration/AllItems.aspx
+                        """.trimIndent()
                 }
                 return null
             }
-
+    
             sharepointApprovalConfiguration.status != "Approved" -> {
                 val logMessage =
                     "ApprovalStatus of ApplicationID $applicationId is ${sharepointApprovalConfiguration.status} and not Approved!"
@@ -134,12 +133,12 @@ open class SharepointClient(private val user: String, private val password: Stri
                     return null
                 }
             }
-
+    
             else -> {
                 logger.info { "ApprovalStatus of ApplicationID is ${sharepointApprovalConfiguration.status}" }
             }
         }
-
+    
         val webapplication = Webapproval.Webapplication(
             certification = Webapproval.Webapplication.Certification(
                 id = applicationId,
@@ -147,27 +146,27 @@ open class SharepointClient(private val user: String, private val password: Stri
             ),
             sharepointUrl = "$ISHARE_WEBAPPLICATION_BY_ID_URL${sharepointApprovalConfiguration.listId}"
         )
-
+    
         return Webapproval(
             url = "$ISHARE_WEBAPPROVAL_BASE_URL${if (isTest) ISHARE_TEST_LIST else ISHARE_PROD_LIST}/AllItems.aspx",
             webapplication = webapplication,
         )
     }
-
+    
     private fun getSharepointApprovalConfigurations(): SharepointApprovalConfigurations {
         val httpGet =
             HttpGet("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approval%20Configuration')/items").apply {
-                addHeader("Accept", "application/json;odata=verbose")
+                addHeader("Accept", JSON_CONTENT_TYPE)
             }
         client.execute(httpGet).use { response ->
             logger.info { "Executed request ${httpGet.requestLine} --- ${response.statusLine}" }
             val content = EntityUtils.toString(response.entity)
             logger.debug { content }
-
+    
             return permissiveObjectMapper.readValue(content, SharepointApprovalConfigurations::class.java)
         }
     }
-
+    
     companion object : KLogging() {
         const val ISHARE_BASE_URL = "https://itm.prg-dc.dhl.com"
         const val ISHARE_WEBAPPROVAL_BASE_URL = "${ISHARE_BASE_URL}/sites/it-sec"
@@ -175,5 +174,6 @@ open class SharepointClient(private val user: String, private val password: Stri
         const val ISHARE_TEST_LIST = "Pipeline%20Approvals%20TEST"
         const val ISHARE_WEBAPPLICATION_BY_ID_URL =
             "https://itm.prg-dc.dhl.com/sites/it-sec/Lists/Pipeline%20Approval%20Configuration/DispForm.aspx?ID="
+        const val JSON_CONTENT_TYPE = "application/json;odata=verbose"
     }
 }

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -21,12 +21,12 @@ data class LicenseBlackListEntry(
 )
 
 object OslcComplianceChecker : KLogging() {
-
+    private const val RESOURCE_NOT_FOUND = "not found"
     private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: RESOURCE_NOT_FOUND
     private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: RESOURCE_NOT_FOUND
+    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: RESOURCE_NOT_FOUND
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -2,18 +2,19 @@ package de.deutschepost.sdm.cdlib.utils
 
 import java.io.File
 import java.security.MessageDigest
+private const val SHA_256 = "SHA-256"
 
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA_256)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -96,7 +96,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
             }
@@ -107,7 +107,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0
@@ -119,7 +119,7 @@ class ChangeOslcIntegrationTest(
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcGradlePluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -216,6 +216,8 @@ class ChangeCloseIntegrationTest(
         }
     }
 
+        companion object { const val DASHBOARD_STATUS_CODE_MESSAGE = "Dashboard status code: 201" }
+        
         "Closing change successfully publishes metrics via Jenkins" {
             withEnvironment(
                 "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -225,20 +227,20 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS_CODE_MESSAGE
                 exitCode shouldBeExactly 0
             }
         }
-
+        
         "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
             withEnvironment(
                 "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -248,28 +250,28 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS_CODE_MESSAGE
                 output shouldContain "INFRA"
                 exitCode shouldBeExactly 0
             }
         }
-
+        
         "Closing change successfully publishes metrics via AzureDevOps" {
             val rnd = UUID.randomUUID().toString().substringBefore("-")
-
+        
             withEnvironment(
                 mapOf(
                     "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
-                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
+                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature"
                 ),
                 OverrideMode.SetOrOverride
             ) {
@@ -277,18 +279,19 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS_CODE_MESSAGE
                 exitCode shouldBeExactly 0
             }
+        }
         }
 
         "Closing change successfully when having a fuzzy matching job url" {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -25,6 +25,11 @@ import java.lang.reflect.Method
 class ChangeCreateCommandTest(
     @Value("\${change-management-token}") val token: String
 ) : StringSpec() {
+
+    companion object {
+        private const val EXCEPTION_MESSAGE = "java.lang.IllegalArgumentException"
+    }
+
     override fun listeners(): List<TestListener> {
         return listOf(
             getSystemEnvironmentTestListenerWithOverrides()
@@ -59,7 +64,6 @@ class ChangeCreateCommandTest(
                     *"--test --jira-token $token".toArgsArray()
                 )
             }
-
             output shouldContain "Missing required argument(s): --commercial-reference=<commercialReference>"
         }
 
@@ -71,7 +75,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain EXCEPTION_MESSAGE
         }
 
         "Command fails if oslc but no distribution was passed" {
@@ -82,7 +86,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain EXCEPTION_MESSAGE
         }
 
         "Command doesn't fail if no-oslc and no distribution was passed" {
@@ -93,7 +97,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain EXCEPTION_MESSAGE
             output shouldContain "Verifying reports..."
         }
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
@@ -64,13 +64,16 @@ class ChangeCreateIntegrationTest(
             )
             .findItSystem(commercialReference)
     }
-
     override fun listeners(): List<TestListener> {
         return listOf(
             getSystemEnvironmentTestListenerWithOverrides()
         )
     }
-
+    
+    companion object {
+        private const val CHECK_STATUS_MESSAGE = "Checking change request status for approval every "
+    }
+    
     init {
         test("testing unsupported CDLib version preventing preauthorization") {
             ApplicationContext.run(
@@ -85,7 +88,7 @@ class ChangeCreateIntegrationTest(
                 }
                 output shouldContain "CDLib version 0.2.0-INTEGRATION-TEST is not supported anymore. Please update to a newer version. Pre-authorization is not possible."
                 output shouldContain "A new version of CDLib is available"
-
+    
                 output shouldContain "Retrieving IT system information"
                 output shouldContain "Searching existing changes for the current pipeline"
                 output shouldContain "Could not find changes to close nor resume for the current pipeline"
@@ -97,16 +100,16 @@ class ChangeCreateIntegrationTest(
                     "  Determined change type --> MINOR"
                 output shouldContain "Updating change request type: MINOR"
                 output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
+                output shouldContain CHECK_STATUS_MESSAGE
                 output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
-
+    
             }
             changeTestHelper.closeChangeRequest(
                 token,
                 commercialReference
             )
         }
-
+    
         withMockedVersionInfo(changeHandler) {
             test("Creating change via full change command fails given an invalid commercial reference") {
                 val (_, output) = withStandardOutput {
@@ -117,17 +120,17 @@ class ChangeCreateIntegrationTest(
                 }
                 output shouldContain "Failed to get commercial reference: DI-123456"
             }
-
+    
             test("Change created with wrong parameters and --trace option extends logging") {
                 val (_, output) = withStandardOutput {
                     val args: Array<String> =
                         "change create --skip-approval-wait --jira-token wrong --no-oslc --no-webapproval --no-tqs --debug --trace --commercial-reference $commercialReference --test".toArgsArray()
                     PicocliRunner.run(CdlibCommand::class.java, *args)
                 }
-
+    
                 output shouldContain "TRACE"
             }
-
+    
             test("Change create command with no open changes for the current pipeline continues successfully with appropriate log") {
                 val (_, output) = withStandardOutput {
                     PicocliRunner.run(
@@ -135,7 +138,7 @@ class ChangeCreateIntegrationTest(
                         *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
                     )
                 }
-
+    
                 output shouldContain "Retrieving IT system information"
                 output shouldContain "Searching existing changes for the current pipeline"
                 output shouldContain "Could not find changes to close nor resume for the current pipeline"
@@ -146,21 +149,20 @@ class ChangeCreateIntegrationTest(
                     "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
                 output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                 output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
+                output shouldContain CHECK_STATUS_MESSAGE
                 output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-
-
-
+    
+    
                 changeTestHelper.closeChangeRequest(token, commercialReference)
             }
-
+    
             context("Change create command with custom details...") {
                 test("...and wrong category fails.") {
                     val (_, output) = withErrorOutput {
                         val toArgsArray = """change create
-                        | --category=wrongCategory
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                            | --category=wrongCategory
+                            | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                            | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
                             .toArgsArray()
                         PicocliRunner.run(
                             CdlibCommand::class.java,
@@ -169,48 +171,48 @@ class ChangeCreateIntegrationTest(
                     }
                     output shouldContain "Invalid value for option '--category': expected one of [ROLLOUT, NO_ROLLOUT, AUTHORIZATIONS, DATA_MAINTENANCE, TECHNICAL_REQUIREMENTS, LEGAL_OR_CONTRACTUAL_REQUIREMENTS, HOUSEKEEPING, CAPACITY_ADJUSTMENTS, SECURITY, TROUBLESHOOTING, OTHER] (case-sensitive) but was 'wrongCategory'"
                 }
-
+    
                 test("...and wrong impactClass fails.") {
                     val (_, output) = withErrorOutput {
                         val toArgsArray = """change create
-                        | --impact-class=wrongImpactClass
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                            | --impact-class=wrongImpactClass
+                            | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                            | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
                             .toArgsArray()
                         PicocliRunner.run(
                             CdlibCommand::class.java,
                             *toArgsArray
                         )
                     }
-
+    
                     output shouldContain "Invalid value for option '--impact-class': expected one of [CRITICAL, HIGH, LOW, MEDIUM, NONE] (case-sensitive) but was 'wrongImpactClass'"
                 }
-
+    
                 test("...is successful with appropriate log and custom comment.") {
                     val test = "test"
                     val toArgsArray = """change create
-                        | --category $HOUSEKEEPING
-                        | --summary $test
-                        | --description $test
-                        | --impact-class $NONE
-                        | --impact $test
-                        | --target $test
-                        | --fallback $test
-                        | --implementation-risk $test
-                        | --omission-risk $test
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
-                        .toArgsArray()
+                            | --category $HOUSEKEEPING
+                            | --summary $test
+                            | --description $test
+                            | --impact-class $NONE
+                            | --impact $test
+                            | --target $test
+                            | --fallback $test
+                            | --implementation-risk $test
+                            | --omission-risk $test
+                            | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                            | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                            .toArgsArray()
                     PicocliRunner.run(
                         CdlibCommand::class.java,
                         *toArgsArray
                     )
-
+    
                     val change = changeHandler
                         .findExisting()
                         .findResumable()
                         .getChange()
-
+    
                     change.category shouldBe HOUSEKEEPING
                     change.summary shouldBe test
                     change.description shouldBe test
@@ -220,11 +222,11 @@ class ChangeCreateIntegrationTest(
                     change.fallback shouldBe test
                     change.implementationRisk shouldBe test
                     change.omissionRisk shouldBe test
-
+    
                     changeHandler.closeExisting()
                 }
             }
-
+    
             test("Change create command with resume flag and changes open for the current pipeline closes all but the latest one and resumes that one successfully") {
                 withEnvironment(
                     "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
@@ -239,7 +241,7 @@ class ChangeCreateIntegrationTest(
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
                 }
-
+    
                 val (_, output) = withStandardOutput {
                     withEnvironment(
                         "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -251,7 +253,7 @@ class ChangeCreateIntegrationTest(
                         )
                     }
                 }
-
+    
                 output shouldContain "Starting Change Management process."
                 output shouldContain "Retrieving IT system information"
                 output shouldContain "Searching existing changes for the current pipeline"
@@ -260,17 +262,17 @@ class ChangeCreateIntegrationTest(
                 output shouldContain "Resuming change: "
                 output shouldContain "Adding resume comment to change..."
                 output shouldContain "Adding new job url to change description..."
-                output shouldContain "Checking change request status for approval every "
+                output shouldContain CHECK_STATUS_MESSAGE
                 output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
                 output shouldNotContain "Posting change request: "
                 output shouldNotContain "Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes."
-
-
+    
+    
                 changeTestHelper.closeChangeRequest(token, commercialReference)
             }
-
+    
             test("Change create command with open changes that are awaiting implementation transitions them to 're-plan', cancels and then closes them") {
-
+    
                 withEnvironment(
                     "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
                     OverrideMode.SetOrOverride
@@ -283,7 +285,7 @@ class ChangeCreateIntegrationTest(
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
                 }
-
+    
                 val (_, output) = withStandardOutput {
                     withEnvironment(
                         "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -295,7 +297,7 @@ class ChangeCreateIntegrationTest(
                         )
                     }
                 }
-
+    
                 output shouldContain "Retrieving IT system information"
                 output shouldContain "Searching existing changes for the current pipeline"
                 output shouldContain "Closing change:"
@@ -310,13 +312,13 @@ class ChangeCreateIntegrationTest(
                     "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
                 output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                 output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
+                output shouldContain CHECK_STATUS_MESSAGE
                 output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
                 output shouldNotContain "Could not find changes to close nor resume for the current pipeline"
-
+    
                 changeTestHelper.closeChangeRequest(token, commercialReference)
             }
-
+    
             context("Change create command during frozen zone") {
                 val (_, output) = withStandardOutput {
                     PicocliRunner.run(
@@ -324,17 +326,17 @@ class ChangeCreateIntegrationTest(
                         *"change create --test --skip-approval-wait --start=2023-01-01T00:00:00+01:00 --no-oslc --no-webapproval --no-tqs --enforce-frozen-zone --jira-token $token --commercial-reference $commercialReference".toArgsArray()
                     )
                 }
-
+    
                 test("...creates a change and progresses it regularly") {
                     output shouldContain "Retrieving IT system information"
                     output shouldContain "Searching existing changes for the current pipeline"
                     output shouldContain "Posting change request"
                 }
-
+    
                 test("...ignores custom change window.") {
                     output shouldContain "Frozen zone active: Ignoring set custom change window."
                 }
-
+    
                 test("...recognises frozen zone") {
                     output shouldContain "Determining whether change can be preauthorized."
                     output shouldContain "  Impact Class: ${NONE.name}\n" +
@@ -342,22 +344,22 @@ class ChangeCreateIntegrationTest(
                         "  Special conditions:\n" +
                         "    Frozen Zone (i.e. Starkverkehr) is active from "
                 }
-
+    
                 test("...updates change type to major") {
                     output shouldContain "  Determined change type --> ${MAJOR.name}"
                     output shouldContain "Updating change request type: ${MAJOR.name}"
                 }
-
+    
                 test("...and does not preauthorize nor approve it") {
                     output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
                     output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
                     output shouldNotContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
                     output shouldNotContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                 }
-
+    
                 changeTestHelper.closeChangeRequest(token, commercialReference)
             }
-
+    
             context("Change create with custom change window...") {
                 val now = ZonedDateTime.now()
                 val (_, output) = withStandardOutput {
@@ -369,9 +371,9 @@ class ChangeCreateIntegrationTest(
                             "--end ${now.plusDays(2).toIso()}").toArgsArray(),
                     )
                 }
-
+    
                 test("...creates a change and progresses it regularly") {
-
+    
                     output shouldContain "Retrieving IT system information"
                     output shouldContain "Searching existing changes for the current pipeline"
                     output shouldContain "Could not find changes to close nor resume for the current pipeline"
@@ -382,9 +384,13 @@ class ChangeCreateIntegrationTest(
                         "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
                     output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                     output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                    output shouldContain "Checking change request status for approval every "
+                    output shouldContain CHECK_STATUS_MESSAGE
                     output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
                 }
+            }
+        }
+    }
+    
 
                 test("...exits when change window is over on a resume run") {
                     val expiredChangeDetails = changeTestHelper.changeDetailsWithDefaults()

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -184,7 +184,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_CRITICALITY,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -196,7 +196,7 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_CRITICALITY,
                                                 6
                                             ),
                                             objectKey = "objectKey",
@@ -251,7 +251,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_CRITICALITY,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -263,7 +263,7 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_CRITICALITY,
                                                 6
                                             ),
                                             objectKey = "objectKey",

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
@@ -25,10 +25,40 @@ import java.time.temporal.ChronoUnit
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 @MicronautTest
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.names.git.GitRepository
+import de.deutschepost.sdm.cdlib.names.git.GitRevision
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.SystemEnvironmentTestListener
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.extensions.time.withConstantNow
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.*
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.mockk.every
+import io.mockk.mockkObject
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
+@MicronautTest
 class NameResolverAzureTest(
     private val resolver: NameResolverAzure,
     private val namesConfigWithDefault: NamesConfigWithDefault
 ) : AnnotationSpec() {
+    companion object {
+        private const val BASE_NAME = "ICTO-3339_SDM-phippyandfriends"
+    }
     private val before = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toInstant()
 
 
@@ -36,7 +66,7 @@ class NameResolverAzureTest(
         SystemEnvironmentTestListener(
             mapOf(
                 "BUILD_BUILDID" to "12657",
-                "BUILD_DEFINITIONNAME" to "ICTO-3339_SDM-phippyandfriends",
+                "BUILD_DEFINITIONNAME" to BASE_NAME,
                 "BUILD_SOURCEBRANCHNAME" to "i593_test",
                 "SYSTEM_COLLECTIONURI" to "https://dev.azure.com/sw-zustellung-31b3183/",
                 "SYSTEM_TEAMPROJECT" to "ICTO-3339_SDM",
@@ -100,7 +130,7 @@ class NameResolverAzureTest(
 
     @Test
     fun testCreate_APP_NAME() {
-        resolver[Names.CDLIB_APP_NAME] shouldBeEqualComparingTo "ICTO-3339_SDM-phippyandfriends"
+        resolver[Names.CDLIB_APP_NAME] shouldBeEqualComparingTo BASE_NAME
     }
 
     @Test
@@ -184,7 +214,7 @@ class NameResolverAzureTest(
     @Test
     fun testCreate_RELEASE_NAME() {
         resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "_12657_a5c5bc3"
-        resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "ICTO-3339_SDM-phippyandfriends"
+        resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase BASE_NAME
     }
 
     @Test
@@ -235,6 +265,15 @@ class NameResolverAzureTest(
         withEnvironment(
             mapOf(
                 "BUILD_DEFINITIONNAME" to "ITR-1337-dulli-daks-orchestrator",
+                "BUILD_SOURCEBRANCHNAME" to "develop-update-flux-deployment"
+            ), OverrideMode.SetOrOverride
+        ) {
+            val newResolver = NameResolverAzure(namesConfigWithDefault)
+            newResolver[Names.CDLIB_RELEASE_NAME_HELM].last().isLetterOrDigit() shouldBe true
+        }
+    }
+}
+
                 "BUILD_SOURCEBRANCHNAME" to "develop-update-flux-deployment",
             ),
             OverrideMode.SetOrOverride

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -19,7 +19,32 @@ import withStandardOutput
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import de.deutschepost.sdm.cdlib.names.git.GitRepository
+import de.deutschepost.sdm.cdlib.names.git.GitRevision
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.SystemEnvironmentTestListener
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.mockk.every
+import io.mockk.mockkObject
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class NamesCommandAzureTest : AnnotationSpec() {
+
+    companion object {
+        private const val VSO_APP_NAME = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+    }
 
     override fun listeners() = listOf(
         SystemEnvironmentTestListener(
@@ -61,7 +86,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
 
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase VSO_APP_NAME
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
@@ -85,7 +110,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             val args = "names create --from-release-name $releaseName".toArgsArray()
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase VSO_APP_NAME
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_VERSION;isOutput=true]20211203.1809.18"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_BUILD_NUMBER;isOutput=true]20210908.16"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
@@ -118,7 +143,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+            output shouldContainIgnoringCase VSO_APP_NAME
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
@@ -127,3 +152,4 @@ class NamesCommandAzureTest : AnnotationSpec() {
 
     }
 }
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -11,6 +11,19 @@ import withStandardOutput
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.string.shouldContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class NamesCommandTest : DescribeSpec({
     describe("cdlib names") {
         describe("names -h") {
@@ -18,7 +31,7 @@ class NamesCommandTest : DescribeSpec({
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(DISPLAY_HELP) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }
@@ -29,7 +42,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(DISPLAY_HELP) {
                 output shouldContain "Create canonical set of standard names and IDs"
                 output shouldContain "Name of optional output file"
                 output shouldContain "Release name to use for derived name creation"
@@ -43,7 +56,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(DISPLAY_HELP) {
                 output shouldContain "Dumps the list of environment variables"
                 output shouldContain "Name of optional output file"
             }
@@ -61,4 +74,9 @@ class NamesCommandTest : DescribeSpec({
             }
         }
     }
-})
+}) {
+    companion object {
+        private const val DISPLAY_HELP = "should display help"
+    }
+}
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -10,7 +10,23 @@ import io.mockk.mockkObject
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names.git
+
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.mockk.every
+import io.mockk.mockkObject
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class RepositoryTest : AnnotationSpec() {
+    companion object {
+        private const val TEST_EMAIL = "f.l@dhl.com"
+    }
+
     private val currDir = System.getProperty("user.dir")
 
     @BeforeAll
@@ -22,9 +38,9 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = TEST_EMAIL,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = TEST_EMAIL
         )
     }
 
@@ -35,9 +51,9 @@ class RepositoryTest : AnnotationSpec() {
         revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.authorEmail shouldBeEqualComparingTo TEST_EMAIL
         revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.committerEmail shouldBeEqualComparingTo TEST_EMAIL
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
@@ -18,9 +18,32 @@ import withStandardOutput
 @RequiresTag("IntegrationTest")
 @Tags("IntegrationTest")
 @MicronautTest
+package de.deutschepost.sdm.cdlib.release
+
+import de.deutschepost.sdm.cdlib.release.report.TestResultPrefixes
+import getSystemEnvironmentTestListenerWithOverrides
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("IntegrationTest")
+@Tags("IntegrationTest")
+@MicronautTest
 class ReportOslcGradlePluginIntegrationTest(
-    @Value("\${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
+    @Value("${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
 ) : FunSpec() {
+
+    companion object {
+        const val POLICY_PROFILE_DISTRIBUTION = "Policy Profile: Distribution"
+    }
 
     private val appName = "cli"
     private val releaseName = "Integration_result_0228"
@@ -68,7 +91,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldNotContain "Unapproved Licenses Count: 0"
             }
 
@@ -79,7 +102,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 0"
             }
 
@@ -90,7 +113,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Alladin Free Public License 9: [com.rabbitmq:amqp-client]"
             }
@@ -102,7 +125,7 @@ class ReportOslcGradlePluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.CheckCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldContain "Policy Profile: Distribution"
+                output shouldContain POLICY_PROFILE_DISTRIBUTION
                 output shouldContain "Unapproved Licenses Count: 1"
                 output shouldContain "Common Development and Distribution License 1.0: [org.apache.tomcat.embed:tomcat-embed-core]"
             }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -18,9 +18,28 @@ import withStandardOutput
 @RequiresTag("IntegrationTest")
 @Tags("IntegrationTest")
 @MicronautTest
+package de.deutschepost.sdm.cdlib.release
+
+import de.deutschepost.sdm.cdlib.release.report.TestResultPrefixes
+import getSystemEnvironmentTestListenerWithOverrides
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("IntegrationTest")
+@Tags("IntegrationTest")
+@MicronautTest
 class ReportOslcNPMPluginIntegrationTest(
-    @Value("\${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
-    @Value("\${artifactory-azure-identity-token}") val artifactoryLCMIdentityToken: String,
+    @Value("${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
+    @Value("${artifactory-azure-identity-token}") val artifactoryLCMIdentityToken: String,
 ) : FunSpec() {
 
     private val appName = "cli"
@@ -30,6 +49,10 @@ class ReportOslcNPMPluginIntegrationTest(
         "src/test/resources/oslc/${TestResultPrefixes.DEFAULT_PREFIX_OSLC_NPM_PLUGIN}_failing.json"
     private val repoName = "sdm-proj-prg-cdlib-cli-appimage"
     private val repoLCMName = "ICTO-3339_sdm_sockshop_release_reports"
+
+    companion object {
+        private const val UPLOADED_ARTIFACT = "Uploaded Artifact:"
+    }
 
     override fun listeners() = listOf(
         getSystemEnvironmentTestListenerWithOverrides(
@@ -58,7 +81,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT
             }
             // TODO: Delete after sundown
             test("Upload OSLC-Plugin report to LCM artifactory") {
@@ -68,7 +91,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT
             }
 
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
@@ -88,9 +111,10 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldNotContain "Uploaded Artifact:"
+                output shouldNotContain UPLOADED_ARTIFACT
             }
         }
     }
 
 }
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -23,7 +23,7 @@ import java.io.File
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class FnciReportTest : FunSpec({
-    val projectPath = "src/test/resources/fnci/fnci-project.json"
+    val projectPath = PROJECT_JSON_PATH
     val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
     context("Project Info") {
         test("Parses projectInfo correctly") {
@@ -52,7 +52,7 @@ class FnciReportTest : FunSpec({
         val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
         test("Generate OslcTestResult") {
             val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
+                OslcTestResult.from(FnciTestResult(projectInfo, inventory), projectPath)
             report.complianceStatus shouldBe OslcComplianceStatus.RED
             report.unapprovedItems.shouldNotBeEmpty()
             defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
@@ -61,7 +61,7 @@ class FnciReportTest : FunSpec({
         test("Only approved is compliant") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                projectPath
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()
@@ -71,9 +71,14 @@ class FnciReportTest : FunSpec({
         test("Canonical file name should depend on project, not files") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                projectPath
             )
             report.canonicalFilename shouldEndWith "${report.projectName}.json"
         }
     }
-})
+}) {
+    companion object {
+        const val PROJECT_JSON_PATH = "src/test/resources/fnci/fnci-project.json"
+    }
+}
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -44,15 +44,16 @@ class OslcComplianceAcceptedListTest : FunSpec() {
     init {
         context("de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.VersionSpecification parsing") {
             test("Testing valid input strings") {
+                val headerInputString = "Input String"
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
+                        headers(headerInputString, "Default Value", "Expected"),
                         row("0.0.0", 0, VersionSpecification(0, 0, 0)),
                         row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
                         row("1.2.3", 0, VersionSpecification(1, 2, 3)),
                         row("1.2.3.4", 0, VersionSpecification(1, 2, 3)),
                         row("1", 0, VersionSpecification(1, 0, 0)),
-                        row("6.6", 6, VersionSpecification(6, 6, 6)),
+                        row("6.6", 6, VersionSpecification(6, 6, 6))
                     )
                 ) { input: String, default: Int, expected: VersionSpecification ->
                     VersionSpecification.fromString(input, default) shouldBe expected
@@ -60,12 +61,13 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             }
 
             test("Testing invalid input strings") {
+                val headerInputString = "Input String"
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value"),
+                        headers(headerInputString, "Default Value"),
                         row("a.b.c", 0),
                         row("error", 0),
-                        row("3,2,5", 0),
+                        row("3,2,5", 0)
                     )
                 ) { input: String, default: Int ->
                     shouldThrow<NumberFormatException> { VersionSpecification.fromString(input, default) }
@@ -73,9 +75,10 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             }
 
             test("Testing valid ranged input strings") {
+                val headerInputString = "Input String"
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
+                        headers(headerInputString, "ExpectedMin", "ExpectedMax"),
                         row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
                         row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
                         row(
@@ -94,7 +97,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
                             VersionSpecification(0, 0, 0),
                             VersionSpecification(Int.MAX_VALUE, Int.MAX_VALUE, Int.MAX_VALUE)
                         ),
-                        row("11.12.13", VersionSpecification(11, 12, 13), VersionSpecification(11, 12, 13)),
+                        row("11.12.13", VersionSpecification(11, 12, 13), VersionSpecification(11, 12, 13))
                     )
                 ) { input: String, min: VersionSpecification, max: VersionSpecification ->
                     VersionSpecification.rangeFromString(input) shouldBe min..max
@@ -102,15 +105,17 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             }
 
             test("Testing invalid ranged input strings") {
+                val headerInputString = "Input String"
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String"),
+                        headers(headerInputString),
                         row("1.2.3-11.12.13-1.2.3"),
-                        row("1-1-1"),
+                        row("1-1-1")
                     )
                 ) { input: String ->
                     shouldThrow<RuntimeException> { VersionSpecification.rangeFromString(input) }
                 }
+            }
             }
 
             test("Testing isInBetween") {

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
@@ -18,7 +18,31 @@ import java.io.File
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.release.report
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import de.deutschepost.sdm.cdlib.release.report.external.OslcGradlePluginTestResult
+import de.deutschepost.sdm.cdlib.release.report.external.from
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcComplianceChecker
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcDependencyLicenseEntry
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcLicenseDefinition
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcLicenseEntry
+import de.deutschepost.sdm.cdlib.utils.defaultObjectMapper
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.io.File
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class OslcComplianceCheckerTest : FunSpec() {
+
+    companion object {
+        const val MOZILLA_PUBLIC_LICENSE_2_0 = "Mozilla Public License 2.0"
+    }
 
     private val disallowedLicensesDistributionPath: String =
         "src/main/resources/oslc/disallowedLicensesDistribution.json"
@@ -34,11 +58,11 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "MPL 2.0",
-                url = "https://www.mozilla.org/en-US/MPL/2.0/",
+                url = "https://www.mozilla.org/en-US/MPL/2.0/"
             )
         )
     )
-    private val licenseMozillaName = "Mozilla Public License 2.0"
+    private val licenseMozillaName = MOZILLA_PUBLIC_LICENSE_2_0
     private val depWithCDDL = OslcDependencyLicenseEntry(
         dependencyName = "test.should.fail:cddl",
         dependencyVersion = "",
@@ -46,7 +70,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0",
-                url = "https://oss.oracle.com/licenses/CDDL",
+                url = "https://oss.oracle.com/licenses/CDDL"
             )
         )
     )
@@ -58,7 +82,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1",
-                url = "https://www.gnu.org/licenses/lgpl-2.1",
+                url = "https://www.gnu.org/licenses/lgpl-2.1"
             )
         )
     )
@@ -70,7 +94,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU LESSER GENERAL PUBLIC LICENSE, Version 3.0",
-                url = "https://www.gnu.org/licenses/lgpl-3.0",
+                url = "https://www.gnu.org/licenses/lgpl-3.0"
             )
         )
     )
@@ -83,7 +107,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception",
-                url = "https://openjdk.java.net/legal/gplv2+ce.html",
+                url = "https://openjdk.java.net/legal/gplv2+ce.html"
             )
         )
     )
@@ -95,7 +119,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "Apache License 2.0",
-                url = "https://www.apache.org/licenses/LICENSE-2.0",
+                url = "https://www.apache.org/licenses/LICENSE-2.0"
             )
         )
     )
@@ -107,7 +131,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "Aladin Free Public License",
-                url = "http://www.artifex.com/downloads/doc/Public.htm",
+                url = "http://www.artifex.com/downloads/doc/Public.htm"
             )
         )
     )
@@ -118,13 +142,13 @@ class OslcComplianceCheckerTest : FunSpec() {
         context("findMatchingLicense Tests") {
             test("Table Test for selected Licenses with distribution") {
                 io.kotest.data.forAll(
-                    row(depWithMozilla, licenseMozillaName),
+                    row(depWithMozilla, MOZILLA_PUBLIC_LICENSE_2_0),
                     row(depWithCDDL, licenseCDDLName),
                     row(depWithLGPL21, licenseLGPL21Name),
                     row(depWithLGPL3, licenseLGPL3Name),
                     row(depWithGPLCE, null),
                     row(depWithAPL2, null),
-                    row(depWithAladin, licenseAlladinName),
+                    row(depWithAladin, licenseAlladinName)
                 ) { dep: OslcDependencyLicenseEntry, licenseName: String? ->
 
                     val output = OslcComplianceChecker.findAllMatchingLicenses(dep, true)
@@ -149,7 +173,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     row(depWithLGPL3, null),
                     row(depWithGPLCE, null),
                     row(depWithAPL2, null),
-                    row(depWithAladin, licenseAlladinName),
+                    row(depWithAladin, licenseAlladinName)
                 ) { dep: OslcDependencyLicenseEntry, licenseName: String? ->
                     val output = OslcComplianceChecker.findAllMatchingLicenses(dep, false)
                     println("Given: ${dep.licenses.joinToString { "[${it.license} - ${it.url}]" }}")
@@ -181,7 +205,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     "GNU Lesser General Public License 2.1" to 9,
                     "GNU General Public License 2.0" to 4,
                     "GNU General Public License 3.0" to 4,
-                    "Mozilla Public License 2.0" to 5
+                    MOZILLA_PUBLIC_LICENSE_2_0 to 5
                 )
                 val notExpectedLicenses = listOf(
                     "Apache License 2.0",
@@ -218,7 +242,7 @@ class OslcComplianceCheckerTest : FunSpec() {
 
                 val expectedLicenses = mapOf(
                     "Alladin Free Public License 9" to 5,
-                    "Academic Free License 3.0" to 3,
+                    "Academic Free License 3.0" to 3
                 )
                 val notExpectedLicenses = listOf(
                     "Apache License 2.0",
@@ -282,7 +306,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                 val epl2 = output.entries.firstOrNull { it.key.license == "Eclipse Public License 2.0" }
                 epl2 shouldNotBe null
                 epl2?.value?.size shouldBe 1
-                val mpl2 = output.entries.firstOrNull { it.key.license == "Mozilla Public License 2.0" }
+                val mpl2 = output.entries.firstOrNull { it.key.license == MOZILLA_PUBLIC_LICENSE_2_0 }
                 mpl2 shouldNotBe null
                 mpl2?.value?.size shouldBe 1
                 val unknown = output.entries.firstOrNull { it.key.license == "UNKNOWN" }
@@ -310,6 +334,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         }
     }
 }
+
 
 private fun printDefinitions(definitions: List<OslcLicenseDefinition>) {
     definitions.forEach {


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: d31d67b

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
