### PR TITLE
Sonar: Define a constant instead of duplicating this literal "SHA-256" 3 times. (rule kotlin:S1192)

### DIFF
--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
@@ -40,8 +40,9 @@ open class SharepointClient(private val user: String, private val password: Stri
         .build()
 
     private fun getDigest(): String? {
+        val jsonOdataHeader = "application/json;odata=verbose"
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/contextinfo").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", jsonOdataHeader)
         }
         return client.execute(httpPost).use { response ->
             logger.info { "Getting Sharepoint Digest: ${response.statusLine}" }
@@ -56,47 +57,48 @@ open class SharepointClient(private val user: String, private val password: Stri
             }
         }
     }
-
+    
     fun addEntryProd(approvalsListItem: SharepointApprovalsListItem) =
         addEntry(approvalsListItem, ISHARE_PROD_LIST)
-
+    
     fun addEntryTest(approvalsListItem: SharepointApprovalsListItem): Webapproval {
         val approvalsListItemTest = approvalsListItem.copy(metadata = SharepointApprovalsListItem.Metadata.TEST)
         return addEntry(approvalsListItemTest, ISHARE_TEST_LIST)
     }
-
+    
     private fun addEntry(
         approvalsListItem: SharepointApprovalsListItem,
         listName: String,
     ): Webapproval {
+        val jsonOdataHeader = "application/json;odata=verbose"
         val digest =
             checkNotNull(getDigest()) {
                 """
                 Failed to get digest for Record.
                 This is eiter a connection issue or a credentials issue. You can check this with following command:
-                curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: application/json;odata=verbose\"""".trimIndent()
+                curl -v --ntlm -u 'USER:PASSWORD' \"$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approvals')\" -H \"Accept: $jsonOdataHeader\""".trimIndent()
             }
-
+    
         val webapprovalWithoutURL =
             checkNotNull(verifyAndGenerateWebapproval(approvalsListItem.applicationId, listName == ISHARE_TEST_LIST)) {
                 "Failed validating approval documents."
             }
-
+    
         val httpEntity = EntityBuilder.create().apply {
             text = permissiveObjectMapper.writeValueAsString(approvalsListItem)
         }.build()
         val httpPost = HttpPost("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('$listName')/items").apply {
-            addHeader("Accept", "application/json;odata=verbose")
+            addHeader("Accept", jsonOdataHeader)
             addHeader("X-RequestDigest", digest)
-            addHeader("Content-Type", "application/json;odata=verbose")
+            addHeader("Content-Type", jsonOdataHeader)
             entity = httpEntity
         }
-
+    
         val webapprovalUrl = client.execute(httpPost).use { response ->
             logger.info { "Adding Record: ${response.statusLine}" }
             val content = EntityUtils.toString(response.entity)
             logger.debug { content }
-
+    
             if (response.statusLine.statusCode != HttpStatus.SC_CREATED) {
                 logger.error { content }
                 throw IllegalStateException("Failed to create Record.")
@@ -109,8 +111,7 @@ open class SharepointClient(private val user: String, private val password: Stri
         logger.info { "EntryUrl: $webapprovalUrl" }
         return webapprovalWithoutURL.copy(url = webapprovalUrl)
     }
-
-
+    
     fun verifyAndGenerateWebapproval(applicationId: Int, isTest: Boolean): Webapproval? {
         val sharepointApprovalConfiguration = getSharepointApprovalConfigurations().findById(applicationId)
         logger.info { "Getting approvalStatus for ApplicationID $applicationId" }
@@ -118,12 +119,12 @@ open class SharepointClient(private val user: String, private val password: Stri
             sharepointApprovalConfiguration?.status == null -> {
                 logger.error {
                     """Cannot find valid pipeline configuration entry for ApplicationID $applicationId
-                    Did you already request one: $ISHARE_WEBAPPROVAL_BASE_URL/Lists/Pipeline%20Approval%20Configuration/AllItems.aspx
-                    """.trimIndent()
+                        Did you already request one: $ISHARE_WEBAPPROVAL_BASE_URL/Lists/Pipeline%20Approval%20Configuration/AllItems.aspx
+                        """.trimIndent()
                 }
                 return null
             }
-
+    
             sharepointApprovalConfiguration.status != "Approved" -> {
                 val logMessage =
                     "ApprovalStatus of ApplicationID $applicationId is ${sharepointApprovalConfiguration.status} and not Approved!"
@@ -134,12 +135,12 @@ open class SharepointClient(private val user: String, private val password: Stri
                     return null
                 }
             }
-
+    
             else -> {
                 logger.info { "ApprovalStatus of ApplicationID is ${sharepointApprovalConfiguration.status}" }
             }
         }
-
+    
         val webapplication = Webapproval.Webapplication(
             certification = Webapproval.Webapplication.Certification(
                 id = applicationId,
@@ -147,23 +148,24 @@ open class SharepointClient(private val user: String, private val password: Stri
             ),
             sharepointUrl = "$ISHARE_WEBAPPLICATION_BY_ID_URL${sharepointApprovalConfiguration.listId}"
         )
-
+    
         return Webapproval(
             url = "$ISHARE_WEBAPPROVAL_BASE_URL${if (isTest) ISHARE_TEST_LIST else ISHARE_PROD_LIST}/AllItems.aspx",
             webapplication = webapplication,
         )
     }
-
+    
     private fun getSharepointApprovalConfigurations(): SharepointApprovalConfigurations {
+        val jsonOdataHeader = "application/json;odata=verbose"
         val httpGet =
             HttpGet("$ISHARE_WEBAPPROVAL_BASE_URL/_api/web/lists/GetByTitle('Pipeline%20Approval%20Configuration')/items").apply {
-                addHeader("Accept", "application/json;odata=verbose")
+                addHeader("Accept", jsonOdataHeader)
             }
         client.execute(httpGet).use { response ->
             logger.info { "Executed request ${httpGet.requestLine} --- ${response.statusLine}" }
             val content = EntityUtils.toString(response.entity)
             logger.debug { content }
-
+    
             return permissiveObjectMapper.readValue(content, SharepointApprovalConfigurations::class.java)
         }
     }

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
@@ -21,12 +21,15 @@ data class LicenseBlackListEntry(
 )
 
 object OslcComplianceChecker : KLogging() {
+    companion object {
+        private const val NOT_FOUND = "not found"
+    }
 
     private val disallowedLicensesDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesDistribution.json")?.path ?: NOT_FOUND
     private val disallowedLicensesNonDistributionPath: String =
-        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: "not found"
-    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: "not found"
+        javaClass.getResource("/oslc/disallowedLicensesNonDistribution.json")?.path ?: NOT_FOUND
+    private val bundlerPath: String = javaClass.getResource("/oslc/licenseBundler.json")?.path ?: NOT_FOUND
 
     private val licenseDefinitionsDistribution: List<OslcLicenseDefinition> by lazy {
         buildDefinitions(

--- a/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
+++ b/cli/src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
@@ -2,18 +2,19 @@ package de.deutschepost.sdm.cdlib.utils
 
 import java.io.File
 import java.security.MessageDigest
+private const val SHA256_ALGORITHM = "SHA-256"
 
 fun String.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA256_ALGORITHM)
     .digest(this.toByteArray())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun File.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA256_ALGORITHM)
     .digest(this.readBytes())
     .fold("") { str, it -> str + "%02x".format(it) }
 
 fun ByteArray.sha256sum(): String = MessageDigest
-    .getInstance("SHA-256")
+    .getInstance(SHA256_ALGORITHM)
     .digest(this)
     .fold("") { str, it -> str + "%02x".format(it) }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
@@ -80,6 +80,7 @@ class ChangeOslcIntegrationTest(
 
     init {
         context("Creating oslc change is a success") {
+            val ENTRY_URL = "EntryUrl: "
             test("change create --oslc missing distribution") {
                 val (ret, output) = withStandardOutput {
                     val args =
@@ -89,37 +90,37 @@ class ChangeOslcIntegrationTest(
                 ret shouldBe -1
                 output shouldContain "IllegalArgumentException"
             }
-
+        
             test("change create with distribution") {
                 val (ret, output) = withStandardOutput {
                     val args =
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcFNCIName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 ret shouldBeExactly 0
             }
-
+        
             test("change create with report from maven plugin") {
                 val (ret, output) = withStandardOutput {
                     val args =
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcMavenPluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0
             }
-
+        
             test("change create with report from gradle plugin") {
                 val (ret, output) = withStandardOutput {
                     val args =
                         "--no-distribution --jira-token $chgToken --artifactory-its-instance --artifactory-identity-token $artifactoryIdentityToken --repo-name $repoName --immutable-repo-name $immutableRepoName --folder-name $oslcGradlePluginName --commercial-reference 5296 --test --debug --no-webapproval --no-tqs".toArgsArray()
                     PicocliRunner.call(ChangeCommand.CreateCommand::class.java, *args)
                 }
-                output shouldContain "EntryUrl: "
+                output shouldContain ENTRY_URL
                 output shouldContain "labels=[cdlib, oslc, test]"
                 output shouldNotContain "com.microsoft.aad.msal4j.MsalClientException: Token not found in the cache"
                 ret shouldBeExactly 0

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -183,6 +183,10 @@ class ChangeCloseIntegrationTest(
         }
         
 
+        companion object {
+            private const val DASHBOARD_STATUS_MESSAGE = "Dashboard status code: 201"
+        }
+        
         "Closing change successfully publishes metrics via Jenkins" {
             withEnvironment(
                 "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -192,20 +196,20 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS_MESSAGE
                 exitCode shouldBeExactly 0
             }
         }
-
+        
         "Closing change successfully publishes metrics via Jenkins as infrastructure deployment" {
             withEnvironment(
                 "CDLIB_JOB_URL" to "http://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -215,28 +219,28 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --token $token --commercial-reference $commercialReference --status $status --deployment-type INFRA".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "http://integration-test-url.jenkuns.example.com"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS_MESSAGE
                 output shouldContain "INFRA"
                 exitCode shouldBeExactly 0
             }
         }
-
+        
         "Closing change successfully publishes metrics via AzureDevOps" {
             val rnd = UUID.randomUUID().toString().substringBefore("-")
-
+        
             withEnvironment(
                 mapOf(
                     "CDLIB_JOB_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends",
-                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature",
+                    "CDLIB_PIPELINE_URL" to "https://dev.azure.com/sw-zustellung-$rnd/ICTO-3339_SDM-phippyandfriends/_build?definitionId=1337&branchFilter=superFeature"
                 ),
                 OverrideMode.SetOrOverride
             ) {
@@ -244,23 +248,23 @@ class ChangeCloseIntegrationTest(
                     .post(changeDetails)
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                 val (exitCode, output) = withStandardOutput {
                     PicocliRunner.call(
                         ChangeCommand.CloseCommand::class.java,
                         *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "https://dev.azure.com/sw-zustellung-$rnd"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS_MESSAGE
                 exitCode shouldBeExactly 0
             }
         }
-
+        
         "Closing change successfully when having a fuzzy matching job url" {
             val rnd = UUID.randomUUID().toString().substringBefore("-")
-
+        
             withEnvironment(
                 "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/i898-build-refactored-test-merged/display/redirect",
                 OverrideMode.SetOrOverride
@@ -270,15 +274,15 @@ class ChangeCloseIntegrationTest(
                     .preauthorize()
                     .transition(OPEN_TO_IMPLEMENTATION)
             }
-
+        
             withEnvironment(
                 mapOf(
                     "CDLIB_PIPELINE_URL" to "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect",
-                    "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends",
+                    "CDLIB_JOB_URL" to "https://dev\"CDLIB_JOB_URL\" to \"https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends\",.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM-phippyandfriends"
                 ),
                 OverrideMode.SetOrOverride
             ) {
-
+        
                 val (exitCode, output) = withStandardOutput {
                     changeHandler
                         .post(changeDetails)
@@ -289,13 +293,14 @@ class ChangeCloseIntegrationTest(
                         *"--test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "https://test.dhl.com/job/$rnd/job/cli/job/test/display/redirect"
                 output shouldContain "https://dev.azure.com/sw-zustellung-31b3183"
-                output shouldContain "Dashboard status code: 201"
+                output shouldContain DASHBOARD_STATUS_MESSAGE
                 exitCode shouldBeExactly 0
             }
         }
+        
 
         "Change close with custom comment is succesful and adds the comment." {
             val test = "test"

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
@@ -58,19 +58,23 @@ class ChangeCloseIntegrationTest(
     )
 
     init {
+        companion object {
+            private const val METRIC_PUSH_MESSAGE = "Pushing following metric object:" 
+        }
+        
         "Closing change with commercial reference is a success" {
             changeHandler
                 .post(changeDetails)
                 .preauthorize()
                 .transition(OPEN_TO_IMPLEMENTATION)
-
+        
             val (exitCode, output) = withStandardOutput {
                 PicocliRunner.call(
                     ChangeCommand.CloseCommand::class.java,
                     *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                 )
             }
-
+        
             output shouldContain "Retrieving IT system information (commercial reference, ALM-ID, name, key)."
             output shouldContain "Finding change to close for the current pipeline."
             output shouldNotContain "Could not find change to close for the current pipeline."
@@ -79,10 +83,10 @@ class ChangeCloseIntegrationTest(
             output shouldNotContain "Could not transition to 'Under Review'."
             output shouldContain "Transitioning to next change request phase."
             output shouldContain "Change request phase transitioned successfully: 'Under Review'. Change was implemented successfully and is to be reviewed."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain METRIC_PUSH_MESSAGE
             exitCode shouldBe 0
         }
-
+        
         "Close change request fails when no change was created" {
             changeHandler
                 .findExisting()
@@ -93,11 +97,11 @@ class ChangeCloseIntegrationTest(
                     *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                 )
             }
-
+        
             closeOutput shouldContain "Could not find change to close for the current pipeline."
             exitCode shouldBe -1
         }
-
+        
         "Close change request fails and prints warnings when multiple changes were created" {
             changeHandler
                 .post(changeDetails)
@@ -106,56 +110,56 @@ class ChangeCloseIntegrationTest(
                 .post(changeDetails)
                 .preauthorize()
                 .transition(OPEN_TO_IMPLEMENTATION)
-
+        
             val (exitCode, closeOutput) = withStandardOutput {
                 PicocliRunner.call(
                     ChangeCommand.CloseCommand::class.java,
                     *"--debug --test --jira-token $token --commercial-reference $commercialReference --status $status".toArgsArray()
                 )
             }
-
+        
             closeOutput shouldContain "Found multiple changes for this pipeline, please close them manually using the links below: "
             exitCode shouldBe -1
         }
-
+        
         "Publishing metrics with invalid parameter status fails and prints warnings" {
             changeHandler
                 .post(changeDetails)
                 .preauthorize()
                 .transition(OPEN_TO_IMPLEMENTATION)
-
+        
             val (exitCode, output) = withStandardOutput {
                 PicocliRunner.call(
                     ChangeCommand.CloseCommand::class.java,
                     *"--debug --test --jira-token $token --commercial-reference $commercialReference --status Invalid".toArgsArray()
                 )
             }
-
+        
             output shouldContain "Failed to parse Pipeline status"
             output shouldNotContain "Failed to create metric object."
             exitCode shouldBe -1
             changeTestHelper.closeChangeRequest(token, commercialReference)
         }
-
+        
         "Publishing metrics with status: SUCCESS is a success" {
             changeHandler
                 .post(changeDetails)
                 .preauthorize()
                 .transition(OPEN_TO_IMPLEMENTATION)
-
+        
             val (exitCode, output) = withStandardOutput {
                 PicocliRunner.call(
                     ChangeCommand.CloseCommand::class.java,
                     *"--debug --test --jira-token $token --commercial-reference $commercialReference --status SUCCESS".toArgsArray()
                 )
             }
-
+        
             output shouldNotContain "Failed to parse Pipeline status"
             output shouldNotContain "Failed to create metric object."
-            output shouldContain "Pushing following metric object:"
+            output shouldContain METRIC_PUSH_MESSAGE
             exitCode shouldBe 0
         }
-
+        
         "Change is not closed for failed status" {
             listOf("FAILED", "FAILURE").forAll {
                 val (exitCode, output) = withStandardOutput {
@@ -170,14 +174,14 @@ class ChangeCloseIntegrationTest(
                 }
                 output shouldNotContain "Closing change"
                 output shouldContain "not closing change request."
-                output shouldContain "Pushing following metric object:"
+                output shouldContain METRIC_PUSH_MESSAGE
                 exitCode shouldBe 0
-
-
+        
                 changeHandler.findExisting().closeExisting()
                 Thread.sleep(15.toDuration(DurationUnit.SECONDS).inWholeMilliseconds)
             }
         }
+        
 
         "Closing change successfully publishes metrics via Jenkins" {
             withEnvironment(

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
@@ -24,7 +24,37 @@ import java.lang.reflect.Method
 @MicronautTest
 class ChangeCreateCommandTest(
     @Value("\${change-management-token}") val token: String
+package de.deutschepost.sdm.cdlib.change.changemanagement
+
+import de.deutschepost.sdm.cdlib.change.ChangeCommand
+import de.deutschepost.sdm.cdlib.change.metrics.model.Deployment
+import getSystemEnvironmentTestListenerWithOverrides
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import toArgsArray
+import withErrorOutput
+import withStandardOutput
+import java.lang.reflect.Method
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
+@MicronautTest
+class ChangeCreateCommandTest(
+    @Value("${change-management-token}") val token: String
 ) : StringSpec() {
+    companion object {
+        private const val ILLEGAL_ARGUMENT_EXCEPTION = "java.lang.IllegalArgumentException"
+    }
+
     override fun listeners(): List<TestListener> {
         return listOf(
             getSystemEnvironmentTestListenerWithOverrides()
@@ -71,7 +101,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
         }
 
         "Command fails if oslc but no distribution was passed" {
@@ -82,7 +112,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
         }
 
         "Command doesn't fail if no-oslc and no distribution was passed" {
@@ -93,7 +123,7 @@ class ChangeCreateCommandTest(
                 )
             }
             exitCode shouldBeExactly -1
-            output shouldContain "java.lang.IllegalArgumentException"
+            output shouldContain ILLEGAL_ARGUMENT_EXCEPTION
             output shouldContain "Verifying reports..."
         }
 
@@ -111,3 +141,4 @@ class ChangeCreateCommandTest(
         }
     }
 }
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
@@ -72,6 +72,10 @@ class ChangeCreateIntegrationTest(
     }
 
     init {
+        companion object {
+            private const val CHECK_STATUS_MSG = "Checking change request status for approval every "
+        }
+        
         test("testing unsupported CDLib version preventing preauthorization") {
             ApplicationContext.run(
                 Environment.CLI, Environment.TEST, "ver02"
@@ -85,7 +89,7 @@ class ChangeCreateIntegrationTest(
                 }
                 output shouldContain "CDLib version 0.2.0-INTEGRATION-TEST is not supported anymore. Please update to a newer version. Pre-authorization is not possible."
                 output shouldContain "A new version of CDLib is available"
-
+        
                 output shouldContain "Retrieving IT system information"
                 output shouldContain "Searching existing changes for the current pipeline"
                 output shouldContain "Could not find changes to close nor resume for the current pipeline"
@@ -97,16 +101,16 @@ class ChangeCreateIntegrationTest(
                     "  Determined change type --> MINOR"
                 output shouldContain "Updating change request type: MINOR"
                 output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
+                output shouldContain CHECK_STATUS_MSG
                 output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
-
+        
             }
             changeTestHelper.closeChangeRequest(
                 token,
                 commercialReference
             )
         }
-
+        
         withMockedVersionInfo(changeHandler) {
             test("Creating change via full change command fails given an invalid commercial reference") {
                 val (_, output) = withStandardOutput {
@@ -117,17 +121,17 @@ class ChangeCreateIntegrationTest(
                 }
                 output shouldContain "Failed to get commercial reference: DI-123456"
             }
-
+        
             test("Change created with wrong parameters and --trace option extends logging") {
                 val (_, output) = withStandardOutput {
                     val args: Array<String> =
                         "change create --skip-approval-wait --jira-token wrong --no-oslc --no-webapproval --no-tqs --debug --trace --commercial-reference $commercialReference --test".toArgsArray()
                     PicocliRunner.run(CdlibCommand::class.java, *args)
                 }
-
+        
                 output shouldContain "TRACE"
             }
-
+        
             test("Change create command with no open changes for the current pipeline continues successfully with appropriate log") {
                 val (_, output) = withStandardOutput {
                     PicocliRunner.run(
@@ -135,7 +139,7 @@ class ChangeCreateIntegrationTest(
                         *"change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token --commercial-reference $commercialReference".toArgsArray()
                     )
                 }
-
+        
                 output shouldContain "Retrieving IT system information"
                 output shouldContain "Searching existing changes for the current pipeline"
                 output shouldContain "Could not find changes to close nor resume for the current pipeline"
@@ -146,21 +150,20 @@ class ChangeCreateIntegrationTest(
                     "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
                 output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                 output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
+                output shouldContain CHECK_STATUS_MSG
                 output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
-
-
-
+        
+        
                 changeTestHelper.closeChangeRequest(token, commercialReference)
             }
-
+        
             context("Change create command with custom details...") {
                 test("...and wrong category fails.") {
                     val (_, output) = withErrorOutput {
                         val toArgsArray = """change create
-                        | --category=wrongCategory
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                                | --category=wrongCategory
+                                | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                                | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
                             .toArgsArray()
                         PicocliRunner.run(
                             CdlibCommand::class.java,
@@ -169,48 +172,48 @@ class ChangeCreateIntegrationTest(
                     }
                     output shouldContain "Invalid value for option '--category': expected one of [ROLLOUT, NO_ROLLOUT, AUTHORIZATIONS, DATA_MAINTENANCE, TECHNICAL_REQUIREMENTS, LEGAL_OR_CONTRACTUAL_REQUIREMENTS, HOUSEKEEPING, CAPACITY_ADJUSTMENTS, SECURITY, TROUBLESHOOTING, OTHER] (case-sensitive) but was 'wrongCategory'"
                 }
-
+        
                 test("...and wrong impactClass fails.") {
                     val (_, output) = withErrorOutput {
                         val toArgsArray = """change create
-                        | --impact-class=wrongImpactClass
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                                | --impact-class=wrongImpactClass
+                                | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                                | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
                             .toArgsArray()
                         PicocliRunner.run(
                             CdlibCommand::class.java,
                             *toArgsArray
                         )
                     }
-
+        
                     output shouldContain "Invalid value for option '--impact-class': expected one of [CRITICAL, HIGH, LOW, MEDIUM, NONE] (case-sensitive) but was 'wrongImpactClass'"
                 }
-
+        
                 test("...is successful with appropriate log and custom comment.") {
                     val test = "test"
                     val toArgsArray = """change create
-                        | --category $HOUSEKEEPING
-                        | --summary $test
-                        | --description $test
-                        | --impact-class $NONE
-                        | --impact $test
-                        | --target $test
-                        | --fallback $test
-                        | --implementation-risk $test
-                        | --omission-risk $test
-                        | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
-                        | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
+                                | --category $HOUSEKEEPING
+                                | --summary $test
+                                | --description $test
+                                | --impact-class $NONE
+                                | --impact $test
+                                | --target $test
+                                | --fallback $test
+                                | --implementation-risk $test
+                                | --omission-risk $test
+                                | --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token
+                                | --commercial-reference $commercialReference""".trimMargin().replace("\n", "")
                         .toArgsArray()
                     PicocliRunner.run(
                         CdlibCommand::class.java,
                         *toArgsArray
                     )
-
+        
                     val change = changeHandler
                         .findExisting()
                         .findResumable()
                         .getChange()
-
+        
                     change.category shouldBe HOUSEKEEPING
                     change.summary shouldBe test
                     change.description shouldBe test
@@ -220,11 +223,11 @@ class ChangeCreateIntegrationTest(
                     change.fallback shouldBe test
                     change.implementationRisk shouldBe test
                     change.omissionRisk shouldBe test
-
+        
                     changeHandler.closeExisting()
                 }
             }
-
+        
             test("Change create command with resume flag and changes open for the current pipeline closes all but the latest one and resumes that one successfully") {
                 withEnvironment(
                     "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
@@ -239,7 +242,7 @@ class ChangeCreateIntegrationTest(
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
                 }
-
+        
                 val (_, output) = withStandardOutput {
                     withEnvironment(
                         "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -251,7 +254,7 @@ class ChangeCreateIntegrationTest(
                         )
                     }
                 }
-
+        
                 output shouldContain "Starting Change Management process."
                 output shouldContain "Retrieving IT system information"
                 output shouldContain "Searching existing changes for the current pipeline"
@@ -260,17 +263,17 @@ class ChangeCreateIntegrationTest(
                 output shouldContain "Resuming change: "
                 output shouldContain "Adding resume comment to change..."
                 output shouldContain "Adding new job url to change description..."
-                output shouldContain "Checking change request status for approval every "
+                output shouldContain CHECK_STATUS_MSG
                 output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
                 output shouldNotContain "Posting change request: "
                 output shouldNotContain "Change request was not approved after $APPROVAL_CHECK_TIMEOUT_IN_MINUTES minutes."
-
-
+        
+        
                 changeTestHelper.closeChangeRequest(token, commercialReference)
             }
-
+        
             test("Change create command with open changes that are awaiting implementation transitions them to 're-plan', cancels and then closes them") {
-
+        
                 withEnvironment(
                     "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1336",
                     OverrideMode.SetOrOverride
@@ -283,7 +286,7 @@ class ChangeCreateIntegrationTest(
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
                 }
-
+        
                 val (_, output) = withStandardOutput {
                     withEnvironment(
                         "CDLIB_JOB_URL" to "https://integration-test-url.jenkuns.example.com/foo/bar/job/1337",
@@ -295,7 +298,7 @@ class ChangeCreateIntegrationTest(
                         )
                     }
                 }
-
+        
                 output shouldContain "Retrieving IT system information"
                 output shouldContain "Searching existing changes for the current pipeline"
                 output shouldContain "Closing change:"
@@ -310,13 +313,13 @@ class ChangeCreateIntegrationTest(
                     "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
                 output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                 output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                output shouldContain "Checking change request status for approval every "
+                output shouldContain CHECK_STATUS_MSG
                 output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
                 output shouldNotContain "Could not find changes to close nor resume for the current pipeline"
-
+        
                 changeTestHelper.closeChangeRequest(token, commercialReference)
             }
-
+        
             context("Change create command during frozen zone") {
                 val (_, output) = withStandardOutput {
                     PicocliRunner.run(
@@ -324,17 +327,17 @@ class ChangeCreateIntegrationTest(
                         *"change create --test --skip-approval-wait --start=2023-01-01T00:00:00+01:00 --no-oslc --no-webapproval --no-tqs --enforce-frozen-zone --jira-token $token --commercial-reference $commercialReference".toArgsArray()
                     )
                 }
-
+        
                 test("...creates a change and progresses it regularly") {
                     output shouldContain "Retrieving IT system information"
                     output shouldContain "Searching existing changes for the current pipeline"
                     output shouldContain "Posting change request"
                 }
-
+        
                 test("...ignores custom change window.") {
                     output shouldContain "Frozen zone active: Ignoring set custom change window."
                 }
-
+        
                 test("...recognises frozen zone") {
                     output shouldContain "Determining whether change can be preauthorized."
                     output shouldContain "  Impact Class: ${NONE.name}\n" +
@@ -342,22 +345,22 @@ class ChangeCreateIntegrationTest(
                         "  Special conditions:\n" +
                         "    Frozen Zone (i.e. Starkverkehr) is active from "
                 }
-
+        
                 test("...updates change type to major") {
                     output shouldContain "  Determined change type --> ${MAJOR.name}"
                     output shouldContain "Updating change request type: ${MAJOR.name}"
                 }
-
+        
                 test("...and does not preauthorize nor approve it") {
                     output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
                     output shouldContain "Checked current change request status: ${WAITING_FOR_APPROVAL.name}"
                     output shouldNotContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
                     output shouldNotContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                 }
-
+        
                 changeTestHelper.closeChangeRequest(token, commercialReference)
             }
-
+        
             context("Change create with custom change window...") {
                 val now = ZonedDateTime.now()
                 val (_, output) = withStandardOutput {
@@ -369,9 +372,9 @@ class ChangeCreateIntegrationTest(
                             "--end ${now.plusDays(2).toIso()}").toArgsArray(),
                     )
                 }
-
+        
                 test("...creates a change and progresses it regularly") {
-
+        
                     output shouldContain "Retrieving IT system information"
                     output shouldContain "Searching existing changes for the current pipeline"
                     output shouldContain "Could not find changes to close nor resume for the current pipeline"
@@ -382,20 +385,20 @@ class ChangeCreateIntegrationTest(
                         "  Determined change type --> ${ApprovalStatus.PREAUTHORIZED.name}"
                     output shouldContain "Updating change request type: ${ApprovalStatus.PREAUTHORIZED.name}"
                     output shouldContain "Transitioning change request phase: ${OPEN_TO_IMPLEMENTATION.name}"
-                    output shouldContain "Checking change request status for approval every "
+                    output shouldContain CHECK_STATUS_MSG
                     output shouldContain "Checked current change request status: ${AWAITING_IMPLEMENTATION.name}"
                 }
-
+        
                 test("...exits when change window is over on a resume run") {
                     val expiredChangeDetails = changeTestHelper.changeDetailsWithDefaults()
                     expiredChangeDetails.startOpt = now.minusHours(5)
                     expiredChangeDetails.endOpt = now.minusHours(4)
-
+        
                     changeHandler
                         .post(expiredChangeDetails)
                         .preauthorize()
                         .transition(OPEN_TO_IMPLEMENTATION)
-
+        
                     val (_, out) = withStandardOutput {
                         withMockedVersionInfo(changeHandler) {
                             PicocliRunner.run(
@@ -404,14 +407,45 @@ class ChangeCreateIntegrationTest(
                             )
                         }
                     }
-
-                    out shouldNotContain "Frozen zone (i.e. Starkverkehr) in effect from" // cut off due to dynamic date
+        
+                    out shouldNotContain "Frozen zone (i.e. Starkverkehr) in effect from"
                     out shouldContain "Change window has expired ("
                     out shouldContain "therefore cannot\nresume and closing this change, please create a new change by re-triggering this run.\nAborting pipeline..."
-
+        
                 }
             }
-
+        
+            context("Create change with wrong custom change window...") {
+                val currentTime = ZonedDateTime.now()
+        
+                test("...exits when start time is before the current time") {
+                    val (_, out) = withStandardOutput {
+                        PicocliRunner.run(
+                            CdlibCommand::class.java,
+                            *("change create --test --no-oslc --no-webapproval --no-tqs --jira-token $token " +
+                                "--commercial-reference $commercialReference " +
+                                "--start ${currentTime.minusDays(2).toIso()} " +
+                                "--end ${currentTime.plusHours(2).toIso()}").toArgsArray()
+                        )
+                    }
+        
+                    out shouldContain "Start date cannot be more than 24 hours in the past."
+                }
+        
+                test("...exits when end time is before start time") {
+                    val (_, out) = withStandardOutput {
+                        PicocliRunner.run(
+                            CdlibCommand::class.java,
+                            *("change create --test --skip-approval-wait --no-oslc --no-webapproval --no-tqs --jira-token $token " +
+                                "--commercial-reference $commercialReference " +
+                                "--start ${currentTime.toIso()} " +
+                                "--end ${currentTime.minusHours(2).toIso()}").toArgsArray()
+                        )
+                    }
+        
+                    out shouldContain "End date needs to be later than the start date."
+                }
+            }
             context("Create change with wrong custom change window...") {
                 val currentTime = ZonedDateTime.now()
 

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
@@ -184,7 +184,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_KRITIKALITAT,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -196,7 +196,7 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_KRITIKALITAT,
                                                 6
                                             ),
                                             objectKey = "objectKey",
@@ -251,7 +251,7 @@ class ChangeManagementRepositoryTest(
                                                             referencedObject = JiraObjectEntry(
                                                                 attributes = listOf(),
                                                                 objectType = JiraObjectType(
-                                                                    name = "Business Kritikalität",
+                                                                    name = BUSINESS_KRITIKALITAT,
                                                                     6
                                                                 ),
                                                                 objectKey = "objectKey",
@@ -263,7 +263,7 @@ class ChangeManagementRepositoryTest(
                                                 )
                                             ),
                                             objectType = JiraObjectType(
-                                                name = "Business Kritikalität",
+                                                name = BUSINESS_KRITIKALITAT,
                                                 6
                                             ),
                                             objectKey = "objectKey",

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
@@ -36,155 +36,192 @@ class NameResolverAzureTest(
         SystemEnvironmentTestListener(
             mapOf(
                 "BUILD_BUILDID" to "12657",
-                "BUILD_DEFINITIONNAME" to "ICTO-3339_SDM-phippyandfriends",
-                "BUILD_SOURCEBRANCHNAME" to "i593_test",
-                "SYSTEM_COLLECTIONURI" to "https://dev.azure.com/sw-zustellung-31b3183/",
-                "SYSTEM_TEAMPROJECT" to "ICTO-3339_SDM",
-                "TF_BUILD" to "True",
-                "SYSTEM_DEFINITIONID" to "912345",
-                "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "i593_test"
-            ),
-            OverrideMode.SetOrOverride
-        )
-    )
-
-    @BeforeAll
-    fun initMocks() {
-        mockkObject(GitRepository)
-        every { GitRepository.getRemoteUrl(any()) } returns "https://git.dhl.com/CDLib/CDLib.git"
-        every { GitRepository.lastBranchCommit(any()) } returns GitRevision(
-            id = "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
-            longMessage = "Dummy \"Commit\"",
-            shortMessage = "Dummy \$Commit",
-            authorName = "Firstname Author",
-            authorEmail = "f.a@dhl.com",
-            committerName = "Firstname Committer",
-            committerEmail = "f.c@dhl.com"
-        )
-    }
-
-    @Test
-    fun testCreate_sanitizedTruncated() {
-        withEnvironment(
-            mapOf(
-                "BUILD_SOURCEBRANCHNAME" to "feature/THIS-is-a-very-long-branch-name-that-needs-to-be-truncated",
-                "CDLIB_EFFECTIVE_BRANCH_NAME" to "feature/THIS-is-a-very-long-branch-name-that-needs-to-be-truncated"
-            ), OverrideMode.SetOrOverride
-        ) {
-            val newResolver = NameResolverAzure(namesConfigWithDefault)
-            newResolver[Names.CDLIB_RELEASE_NAME_HELM] shouldBe "icto-3339_sdm-phippyandfriends-feature-this-is-a-very"
-            newResolver[Names.CDLIB_RELEASE_NAME_HELM].length shouldBe 53
-        }
-        withEnvironment(
-            mapOf(
-                "BUILD_SOURCEBRANCHNAME" to "renovate/THIS-is-a-very-long-branch-name-that-needs-to-be-truncated",
-                "CDLIB_EFFECTIVE_BRANCH_NAME" to "renovate/THIS-is-a-very-long-branch-name-that-needs-to-be-truncated"
-            ), OverrideMode.SetOrOverride
-        ) {
-            val newResolver = NameResolverAzure(namesConfigWithDefault)
-            newResolver[Names.CDLIB_RELEASE_NAME_HELM] shouldBe "icto-3339_sdm-phippyandfriends--needs-to-be-truncated"
-            newResolver[Names.CDLIB_RELEASE_NAME_HELM].length shouldBe 53
-        }
-        withEnvironment(
-            mapOf(
-                "BUILD_DEFINITIONNAME" to "ICTO-3339_SDM-phippyandfriends-very-long-app-name-that-needs-to-be-truncated",
-                "BUILD_SOURCEBRANCHNAME" to "renovate/this-is-a-very-long-branch-name-that-needs-to-be-truncated",
-                "CDLIB_EFFECTIVE_BRANCH_NAME" to "renovate/this-is-a-very-long-branch-name-that-needs-to-be-truncated"
-            ), OverrideMode.SetOrOverride
-        ) {
-            val newResolver = NameResolverAzure(namesConfigWithDefault)
-            newResolver[Names.CDLIB_RELEASE_NAME_HELM] shouldBe "icto-3339_sdm-phippyandfriends-very-long-app-name-tha"
-            newResolver[Names.CDLIB_RELEASE_NAME_HELM].length shouldBe 53
-        }
-    }
-
-    @Test
-    fun testCreate_APP_NAME() {
-        resolver[Names.CDLIB_APP_NAME] shouldBeEqualComparingTo "ICTO-3339_SDM-phippyandfriends"
-    }
-
-    @Test
-    fun testCreate_APP_VERSION() {
-        withConstantNow(ZonedDateTime.of(2022, 1, 1, 0, 2, 4, 4, ZoneId.systemDefault())) {
-            resolver[Names.CDLIB_APP_VERSION] shouldBe "20220101.2.4"
-        }
-    }
-
-    @Test
-    fun testCreate_CHART_VERSION() {
-        resolver[Names.CDLIB_CHART_VERSION] shouldHaveMaxLength 35
-        resolver[Names.CDLIB_CHART_VERSION] shouldContain "-i593"
-    }
-
-    @Test
-    fun testCreate_CHART_VERSION_OCI() {
-        resolver[Names.CDLIB_CHART_VERSION_OCI] shouldHaveMaxLength 35
-        resolver[Names.CDLIB_CHART_VERSION_OCI] shouldContain "-i593"
-        resolver[Names.CDLIB_CHART_VERSION_OCI] shouldEndWith "-helm"
-    }
-
-    @Test
-    fun testCreate_CONTAINER_TAG() {
-        resolver[Names.CDLIB_CONTAINER_TAG] shouldHaveMaxLength 35
-        resolver[Names.CDLIB_CONTAINER_TAG] shouldContain "-i593"
-    }
-
-    @Test
-    fun testCreate_EFFECTIVE_BRANCH_NAME() {
-        resolver[Names.CDLIB_EFFECTIVE_BRANCH_NAME] shouldBeEqualIgnoringCase "i593_test"
-    }
-
-    @Test
-    fun testCreate_JOB_URL() {
-        resolver[Names.CDLIB_JOB_URL] shouldContainIgnoringCase "https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM/_build/results?buildId=12657"
-    }
-
-    @Test
-    fun testCreate_PIPELINE_URL_pullRequestSourceBranchName() {
-        withEnvironment(
-            mapOf(
-                "BUILD_SOURCEBRANCHNAME" to "merge",
-                "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "i593_test"
-            ),
-            OverrideMode.SetOrOverride
-        ) {
-            resolver[Names.CDLIB_PIPELINE_URL] shouldContainIgnoringCase "912345"
-            resolver[Names.CDLIB_PIPELINE_URL] shouldContainIgnoringCase "i593_test"
-            resolver[Names.CDLIB_PIPELINE_URL] shouldNotContainIgnoringCase "merge"
-        }
-    }
-
-    @Test
-    fun testCreate_PIPELINE_URL_sourceBranchName() {
-        withEnvironment(
-            mapOf(
-                "BUILD_SOURCEBRANCHNAME" to "i593_test"
-            ), OverrideMode.SetOrOverride
-        ) {
-            resolver[Names.CDLIB_PIPELINE_URL] shouldContainIgnoringCase "912345"
-            resolver[Names.CDLIB_PIPELINE_URL] shouldContainIgnoringCase "i593_test"
-        }
-    }
-
-    @Test
-    fun testCreate_PM_VALUES() {
-        resolver[Names.CDLIB_PM_GIT_ID] shouldBeEqualIgnoringCase "a5c5bc3ce1907e844490697b9aa22c4196c5d781"
-        resolver[Names.CDLIB_PM_GIT_MAIL] shouldBeEqualIgnoringCase "f.c@dhl.com"
-        resolver[Names.CDLIB_PM_GIT_MESSAGE] shouldBeEqualIgnoringCase "Dummy Commit"
-        resolver[Names.CDLIB_PM_GIT_NAME] shouldBeEqualIgnoringCase "Firstname Committer"
-        resolver[Names.CDLIB_PM_GIT_ORIGIN] shouldBeEqualIgnoringCase "https://git.dhl.com/CDLib/CDlib.git"
-        resolver[Names.CDLIB_PM_GIT_LINK] shouldBeEqualIgnoringCase "https://git.dhl.com/CDLib/CDlib/commit/a5c5bc3ce1907e844490697b9aa22c4196c5d781"
-    }
-
-    @Test
-    fun testCreate_RELEASE_VERSION() {
-        resolver[Names.CDLIB_RELEASE_VERSION] shouldContainIgnoringCase "_12657_a5c5bc3"
-    }
-
-    @Test
-    fun testCreate_RELEASE_NAME() {
-        resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "_12657_a5c5bc3"
-        resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "ICTO-3339_SDM-phippyandfriends"
+                companion object {
+                    private const val BASE_RELEASE_NAME = "ICTO-3339_SDM-phippyandfriends"
+                }
+                SystemEnvironmentTestListener(
+                    mapOf(
+                        "BUILD_BUILDID" to "12657",
+                        "BUILD_DEFINITIONNAME" to BASE_RELEASE_NAME,
+                        "BUILD_SOURCEBRANCHNAME" to "i593_test",
+                        "SYSTEM_COLLECTIONURI" to "https://dev.azure.com/sw-zustellung-31b3183/",
+                        "SYSTEM_TEAMPROJECT" to "ICTO-3339_SDM",
+                        "TF_BUILD" to "True",
+                        "SYSTEM_DEFINITIONID" to "912345",
+                        "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "i593_test"
+                    ),
+                    OverrideMode.SetOrOverride
+                )
+                
+                @BeforeAll
+                fun initMocks() {
+                    mockkObject(GitRepository)
+                    every { GitRepository.getRemoteUrl(any()) } returns "https://git.dhl.com/CDLib/CDLib.git"
+                    every { GitRepository.lastBranchCommit(any()) } returns GitRevision(
+                        id = "a5c5bc3ce1907e844490697b9aa22c4196c5d781",
+                        longMessage = "Dummy \"Commit\"",
+                        shortMessage = "Dummy \$Commit",
+                        authorName = "Firstname Author",
+                        authorEmail = "f.a@dhl.com",
+                        committerName = "Firstname Committer",
+                        committerEmail = "f.c@dhl.com"
+                    )
+                }
+                
+                @Test
+                fun testCreate_sanitizedTruncated() {
+                    withEnvironment(
+                        mapOf(
+                            "BUILD_SOURCEBRANCHNAME" to "feature/THIS-is-a-very-long-branch-name-that-needs-to-be-truncated",
+                            "CDLIB_EFFECTIVE_BRANCH_NAME" to "feature/THIS-is-a-very-long-branch-name-that-needs-to-be-truncated"
+                        ), OverrideMode.SetOrOverride
+                    ) {
+                        val newResolver = NameResolverAzure(namesConfigWithDefault)
+                        newResolver[Names.CDLIB_RELEASE_NAME_HELM] shouldBe "icto-3339_sdm-phippyandfriends-feature-this-is-a-very"
+                        newResolver[Names.CDLIB_RELEASE_NAME_HELM].length shouldBe 53
+                    }
+                    withEnvironment(
+                        mapOf(
+                            "BUILD_SOURCEBRANCHNAME" to "renovate/THIS-is-a-very-long-branch-name-that-needs-to-be-truncated",
+                            "CDLIB_EFFECTIVE_BRANCH_NAME" to "renovate/THIS-is-a-very-long-branch-name-that-needs-to-be-truncated"
+                        ), OverrideMode.SetOrOverride
+                    ) {
+                        val newResolver = NameResolverAzure(namesConfigWithDefault)
+                        newResolver[Names.CDLIB_RELEASE_NAME_HELM] shouldBe "icto-3339_sdm-phippyandfriends--needs-to-be-truncated"
+                        newResolver[Names.CDLIB_RELEASE_NAME_HELM].length shouldBe 53
+                    }
+                    withEnvironment(
+                        mapOf(
+                            "BUILD_DEFINITIONNAME" to BASE_RELEASE_NAME + "-very-long-app-name-that-needs-to-be-truncated",
+                            "BUILD_SOURCEBRANCHNAME" to "renovate/this-is-a-very-long-branch-name-that-needs-to-be-truncated",
+                            "CDLIB_EFFECTIVE_BRANCH_NAME" to "renovate/this-is-a-very-long-branch-name-that-needs-to-be-truncated"
+                        ), OverrideMode.SetOrOverride
+                    ) {
+                        val newResolver = NameResolverAzure(namesConfigWithDefault)
+                        newResolver[Names.CDLIB_RELEASE_NAME_HELM] shouldBe "icto-3339_sdm-phippyandfriends-very-long-app-name-tha"
+                        newResolver[Names.CDLIB_RELEASE_NAME_HELM].length shouldBe 53
+                    }
+                }
+                
+                @Test
+                fun testCreate_APP_NAME() {
+                    resolver[Names.CDLIB_APP_NAME] shouldBeEqualComparingTo BASE_RELEASE_NAME
+                }
+                
+                @Test
+                fun testCreate_APP_VERSION() {
+                    withConstantNow(ZonedDateTime.of(2022, 1, 1, 0, 2, 4, 4, ZoneId.systemDefault())) {
+                        resolver[Names.CDLIB_APP_VERSION] shouldBe "20220101.2.4"
+                    }
+                }
+                
+                @Test
+                fun testCreate_CHART_VERSION() {
+                    resolver[Names.CDLIB_CHART_VERSION] shouldHaveMaxLength 35
+                    resolver[Names.CDLIB_CHART_VERSION] shouldContain "-i593"
+                }
+                
+                @Test
+                fun testCreate_CHART_VERSION_OCI() {
+                    resolver[Names.CDLIB_CHART_VERSION_OCI] shouldHaveMaxLength 35
+                    resolver[Names.CDLIB_CHART_VERSION_OCI] shouldContain "-i593"
+                    resolver[Names.CDLIB_CHART_VERSION_OCI] shouldEndWith "-helm"
+                }
+                
+                @Test
+                fun testCreate_CONTAINER_TAG() {
+                    resolver[Names.CDLIB_CONTAINER_TAG] shouldHaveMaxLength 35
+                    resolver[Names.CDLIB_CONTAINER_TAG] shouldContain "-i593"
+                }
+                
+                @Test
+                fun testCreate_EFFECTIVE_BRANCH_NAME() {
+                    resolver[Names.CDLIB_EFFECTIVE_BRANCH_NAME] shouldBeEqualIgnoringCase "i593_test"
+                }
+                
+                @Test
+                fun testCreate_JOB_URL() {
+                    resolver[Names.CDLIB_JOB_URL] shouldContainIgnoringCase "https://dev.azure.com/sw-zustellung-31b3183/ICTO-3339_SDM/_build/results?buildId=12657"
+                }
+                
+                @Test
+                fun testCreate_PIPELINE_URL_pullRequestSourceBranchName() {
+                    withEnvironment(
+                        mapOf(
+                            "BUILD_SOURCEBRANCHNAME" to "merge",
+                            "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "i593_test"
+                        ),
+                        OverrideMode.SetOrOverride
+                    ) {
+                        resolver[Names.CDLIB_PIPELINE_URL] shouldContainIgnoringCase "912345"
+                        resolver[Names.CDLIB_PIPELINE_URL] shouldContainIgnoringCase "i593_test"
+                        resolver[Names.CDLIB_PIPELINE_URL] shouldNotContainIgnoringCase "merge"
+                    }
+                }
+                
+                @Test
+                fun testCreate_PIPELINE_URL_sourceBranchName() {
+                    withEnvironment(
+                        mapOf(
+                            "BUILD_SOURCEBRANCHNAME" to "i593_test"
+                        ), OverrideMode.SetOrOverride
+                    ) {
+                        resolver[Names.CDLIB_PIPELINE_URL] shouldContainIgnoringCase "912345"
+                        resolver[Names.CDLIB_PIPELINE_URL] shouldContainIgnoringCase "i593_test"
+                    }
+                }
+                
+                @Test
+                fun testCreate_PM_VALUES() {
+                    resolver[Names.CDLIB_PM_GIT_ID] shouldBeEqualIgnoringCase "a5c5bc3ce1907e844490697b9aa22c4196c5d781"
+                    resolver[Names.CDLIB_PM_GIT_MAIL] shouldBeEqualIgnoringCase "f.c@dhl.com"
+                    resolver[Names.CDLIB_PM_GIT_MESSAGE] shouldBeEqualIgnoringCase "Dummy Commit"
+                    resolver[Names.CDLIB_PM_GIT_NAME] shouldBeEqualIgnoringCase "Firstname Committer"
+                    resolver[Names.CDLIB_PM_GIT_ORIGIN] shouldBeEqualIgnoringCase "https://git.dhl.com/CDLib/CDlib.git"
+                    resolver[Names.CDLIB_PM_GIT_LINK] shouldBeEqualIgnoringCase "https://git.dhl.com/CDLib/CDlib/commit/a5c5bc3ce1907e844490697b9aa22c4196c5d781"
+                }
+                
+                @Test
+                fun testCreate_RELEASE_VERSION() {
+                    resolver[Names.CDLIB_RELEASE_VERSION] shouldContainIgnoringCase "_12657_a5c5bc3"
+                }
+                
+                @Test
+                fun testCreate_RELEASE_NAME() {
+                    resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase "_12657_a5c5bc3"
+                    resolver[Names.CDLIB_RELEASE_NAME] shouldContainIgnoringCase BASE_RELEASE_NAME
+                }
+                
+                @Test
+                fun testCreate_RELEASE_NAME_FORTIFY() {
+                    resolver[Names.CDLIB_RELEASE_NAME_FORTIFY] shouldContainIgnoringCase "ICTO_3339_SDM_phippyandfriends"
+                }
+                
+                @Test
+                fun testCreate_RELEASE_NAME_HELM() {
+                    resolver[Names.CDLIB_RELEASE_NAME_HELM] shouldHaveMaxLength 53
+                    resolver[Names.CDLIB_RELEASE_NAME_HELM] shouldBeEqualIgnoringCase "ICTO-3339_SDM-phippyandfriends-i593-test"
+                }
+                
+                @Test
+                fun testCreate_REVISION() {
+                    resolver[Names.CDLIB_REVISION] shouldBeEqualComparingTo "a5c5bc3"
+                }
+                
+                @Test
+                fun testCreate_SANITIZED_BRANCH_NAME() {
+                    resolver[Names.CDLIB_SANITIZED_BRANCH_NAME] shouldBeEqualComparingTo "i593-test"
+                }
+                
+                @Test
+                fun testCreate_SEMANTIC_VERSION() {
+                    resolver[Names.CDLIB_SEMANTIC_VERSION] shouldContainIgnoringCase "-i593_test.12657.a5c5bc3"
+                }
+                
+                @Test
+                fun testCreate_TERRAFORM_PREFIX() {
+                    resolver[Names.CDLIB_TERRAFORM_PREFIX] shouldContainIgnoringCase "CDLib-i593-test"
+                }
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
@@ -19,7 +19,32 @@ import withStandardOutput
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import de.deutschepost.sdm.cdlib.names.git.GitRepository
+import de.deutschepost.sdm.cdlib.names.git.GitRevision
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.SystemEnvironmentTestListener
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.mockk.every
+import io.mockk.mockkObject
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class NamesCommandAzureTest : AnnotationSpec() {
+
+    companion object {
+        const val VSO_APP_NAME = "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+    }
 
     override fun listeners() = listOf(
         SystemEnvironmentTestListener(
@@ -34,7 +59,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
                 "SYSTEM_DEFINITIONID" to "101010",
                 // Explicit set / reset var. relevant for platform detection
                 "TF_BUILD" to "True",
-                "JENKINS_HOME" to "",
+                "JENKINS_HOME" to ""
             ), OverrideMode.SetOrOverride
         )
     )
@@ -61,7 +86,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
 
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase VSO_APP_NAME
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"
@@ -85,7 +110,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
             val args = "names create --from-release-name $releaseName".toArgsArray()
             PicocliRunner.run(CdlibCommand::class.java, *args)
         }
-        output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+        output shouldContainIgnoringCase VSO_APP_NAME
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_VERSION;isOutput=true]20211203.1809.18"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_BUILD_NUMBER;isOutput=true]20210908.16"
         output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
@@ -109,7 +134,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
         withEnvironment(
             mapOf(
                 "SYSTEM_PULLREQUEST_SOURCEBRANCH" to "refs/heads/i593_test",
-                "BUILD_SOURCEBRANCHNAME" to "merge",
+                "BUILD_SOURCEBRANCHNAME" to "merge"
             ),
             OverrideMode.SetOrOverride
         ) {
@@ -118,7 +143,7 @@ class NamesCommandAzureTest : AnnotationSpec() {
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_APP_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends"
+            output shouldContainIgnoringCase VSO_APP_NAME
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_EFFECTIVE_BRANCH_NAME;isOutput=true]i593_test"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_PM_GIT_ID;isOutput=true]a5c5bc3ce1907e844490697b9aa22c4196c5d781"
             output shouldContainIgnoringCase "##vso[task.setvariable variable=CDLIB_RELEASE_NAME;isOutput=true]ICTO-3339_SDM-phippyandfriends_"

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
@@ -11,6 +11,19 @@ import withStandardOutput
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.names
+
+import de.deutschepost.sdm.cdlib.CdlibCommand
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.string.shouldContain
+import io.micronaut.configuration.picocli.PicocliRunner
+import toArgsArray
+import withStandardOutput
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class NamesCommandTest : DescribeSpec({
     describe("cdlib names") {
         describe("names -h") {
@@ -18,7 +31,7 @@ class NamesCommandTest : DescribeSpec({
                 val args = "names -h".toArgsArray()
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
-            it("should display help") {
+            it(DISPLAY_HELP) {
                 output shouldContain "Contains subcommands for automatic name and ID creation in pipeline"
             }
         }
@@ -29,7 +42,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(DISPLAY_HELP) {
                 output shouldContain "Create canonical set of standard names and IDs"
                 output shouldContain "Name of optional output file"
                 output shouldContain "Release name to use for derived name creation"
@@ -43,7 +56,7 @@ class NamesCommandTest : DescribeSpec({
                 PicocliRunner.run(CdlibCommand::class.java, *args)
             }
 
-            it("should display help") {
+            it(DISPLAY_HELP) {
                 output shouldContain "Dumps the list of environment variables"
                 output shouldContain "Name of optional output file"
             }
@@ -61,4 +74,9 @@ class NamesCommandTest : DescribeSpec({
             }
         }
     }
-})
+}) {
+    companion object {
+        private const val DISPLAY_HELP = "should display help"
+    }
+}
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
@@ -14,6 +14,10 @@ class RepositoryTest : AnnotationSpec() {
     private val currDir = System.getProperty("user.dir")
 
     @BeforeAll
+    companion object {
+        private const val DHL_EMAIL = "f.l@dhl.com"
+    }
+    
     fun initMocks() {
         mockkObject(GitRepository)
         every { GitRepository.getRemoteUrl(any()) } returns "https://git.dhl.com/CDLib/CDlib.git"
@@ -22,12 +26,12 @@ class RepositoryTest : AnnotationSpec() {
             longMessage = "Dummy Commit",
             shortMessage = "Dummy Commit",
             authorName = "Firstname Lastname",
-            authorEmail = "f.l@dhl.com",
+            authorEmail = DHL_EMAIL,
             committerName = "Firstname Lastname",
-            committerEmail = "f.l@dhl.com"
+            committerEmail = DHL_EMAIL
         )
     }
-
+    
     @Test
     fun testLastCommit() {
         val revision = GitRepository.lastBranchCommit(currDir)
@@ -35,9 +39,9 @@ class RepositoryTest : AnnotationSpec() {
         revision.longMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.shortMessage shouldBeEqualComparingTo "Dummy Commit"
         revision.authorName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.authorEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.authorEmail shouldBeEqualComparingTo DHL_EMAIL
         revision.committerName shouldBeEqualComparingTo "Firstname Lastname"
-        revision.committerEmail shouldBeEqualComparingTo "f.l@dhl.com"
+        revision.committerEmail shouldBeEqualComparingTo DHL_EMAIL
     }
 
     @Test

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
@@ -19,9 +19,13 @@ import withStandardOutput
 @Tags("IntegrationTest")
 @MicronautTest
 class ReportOslcNPMPluginIntegrationTest(
-    @Value("\${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
-    @Value("\${artifactory-azure-identity-token}") val artifactoryLCMIdentityToken: String,
+    @Value("${artifactory-its-identity-token}") val artifactoryIdentityToken: String,
+    @Value("${artifactory-azure-identity-token}") val artifactoryLCMIdentityToken: String,
 ) : FunSpec() {
+
+    companion object {
+        const val UPLOADED_ARTIFACT = "Uploaded Artifact:"
+    }
 
     private val appName = "cli"
     private val releaseName = "Integration_result_0228"
@@ -58,7 +62,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT
             }
             // TODO: Delete after sundown
             test("Upload OSLC-Plugin report to LCM artifactory") {
@@ -68,7 +72,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly 0
-                output shouldContain "Uploaded Artifact:"
+                output shouldContain UPLOADED_ARTIFACT
             }
 
             test("Check OSLC-Plugin report locally should fail due to distribution flag") {
@@ -88,7 +92,7 @@ class ReportOslcNPMPluginIntegrationTest(
                     PicocliRunner.call(ReportCommand.UploadCommand::class.java, *args)
                 }
                 ret shouldBeExactly -1
-                output shouldNotContain "Uploaded Artifact:"
+                output shouldNotContain UPLOADED_ARTIFACT
             }
         }
     }

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
@@ -23,8 +23,9 @@ import java.io.File
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
 class FnciReportTest : FunSpec({
-    val projectPath = "src/test/resources/fnci/fnci-project.json"
+    val projectPath = PROJECT_FILE_PATH
     val inventoryPath = "src/test/resources/fnci/fnci-inventory.json"
+    
     context("Project Info") {
         test("Parses projectInfo correctly") {
             val projectInfo = permissiveObjectMapper.readValue(
@@ -52,7 +53,7 @@ class FnciReportTest : FunSpec({
         val inventory: List<FnciInventoryItem> = permissiveObjectMapper.readValue(File(inventoryPath))
         test("Generate OslcTestResult") {
             val report =
-                OslcTestResult.from(FnciTestResult(projectInfo, inventory), "src/test/resources/fnci/fnci-project.json")
+                OslcTestResult.from(FnciTestResult(projectInfo, inventory), PROJECT_FILE_PATH)
             report.complianceStatus shouldBe OslcComplianceStatus.RED
             report.unapprovedItems.shouldNotBeEmpty()
             defaultObjectMapper.writerWithDefaultPrettyPrinter().writeValue(System.out, report)
@@ -61,7 +62,7 @@ class FnciReportTest : FunSpec({
         test("Only approved is compliant") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                PROJECT_FILE_PATH
             )
             report.complianceStatus shouldBe OslcComplianceStatus.GREEN
             report.unapprovedItems.shouldBeEmpty()
@@ -71,9 +72,14 @@ class FnciReportTest : FunSpec({
         test("Canonical file name should depend on project, not files") {
             val report = OslcTestResult.from(
                 FnciTestResult(projectInfo, inventory.filter { it.inventoryReviewStatus == "Approved" }),
-                "src/test/resources/fnci/fnci-project.json"
+                PROJECT_FILE_PATH
             )
             report.canonicalFilename shouldEndWith "${report.projectName}.json"
         }
     }
-})
+}) {
+    companion object {
+        private const val PROJECT_FILE_PATH = "src/test/resources/fnci/fnci-project.json"
+    }
+}
+

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
@@ -46,7 +46,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value", "Expected"),
+                        headers(HEADER_INPUT_STRING, "Default Value", "Expected"),
                         row("0.0.0", 0, VersionSpecification(0, 0, 0)),
                         row("0.0.0", Int.MAX_VALUE, VersionSpecification(0, 0, 0)),
                         row("1.2.3", 0, VersionSpecification(1, 2, 3)),
@@ -62,7 +62,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing invalid input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "Default Value"),
+                        headers(HEADER_INPUT_STRING, "Default Value"),
                         row("a.b.c", 0),
                         row("error", 0),
                         row("3,2,5", 0),
@@ -75,7 +75,7 @@ class OslcComplianceAcceptedListTest : FunSpec() {
             test("Testing valid ranged input strings") {
                 io.kotest.data.forAll(
                     table(
-                        headers("Input String", "ExpectedMin", "ExpectedMax"),
+                        headers(HEADER_INPUT_STRING, "ExpectedMin", "ExpectedMax"),
                         row("1.2.3-11.12.13", VersionSpecification(1, 2, 3), VersionSpecification(11, 12, 13)),
                         row("-11.12.13", VersionSpecification(0, 0, 0), VersionSpecification(11, 12, 13)),
                         row(
@@ -100,11 +100,6 @@ class OslcComplianceAcceptedListTest : FunSpec() {
                     VersionSpecification.rangeFromString(input) shouldBe min..max
                 }
             }
-
-            test("Testing invalid ranged input strings") {
-                io.kotest.data.forAll(
-                    table(
-                        headers("Input String"),
                         row("1.2.3-11.12.13-1.2.3"),
                         row("1-1-1"),
                     )

--- a/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
+++ b/cli/src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
@@ -18,7 +18,31 @@ import java.io.File
 
 @RequiresTag("UnitTest")
 @Tags("UnitTest")
+package de.deutschepost.sdm.cdlib.release.report
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import de.deutschepost.sdm.cdlib.release.report.external.OslcGradlePluginTestResult
+import de.deutschepost.sdm.cdlib.release.report.external.from
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcComplianceChecker
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcDependencyLicenseEntry
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcLicenseDefinition
+import de.deutschepost.sdm.cdlib.release.report.internal.oslcComplianceChecker.OslcLicenseEntry
+import de.deutschepost.sdm.cdlib.utils.defaultObjectMapper
+import io.kotest.core.annotation.RequiresTag
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.io.File
+
+@RequiresTag("UnitTest")
+@Tags("UnitTest")
 class OslcComplianceCheckerTest : FunSpec() {
+
+    companion object {
+        const val MPL_LICENSE = "Mozilla Public License 2.0"
+    }
 
     private val disallowedLicensesDistributionPath: String =
         "src/main/resources/oslc/disallowedLicensesDistribution.json"
@@ -34,11 +58,11 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "MPL 2.0",
-                url = "https://www.mozilla.org/en-US/MPL/2.0/",
+                url = "https://www.mozilla.org/en-US/MPL/2.0/"
             )
         )
     )
-    private val licenseMozillaName = "Mozilla Public License 2.0"
+    private val licenseMozillaName = MPL_LICENSE
     private val depWithCDDL = OslcDependencyLicenseEntry(
         dependencyName = "test.should.fail:cddl",
         dependencyVersion = "",
@@ -46,7 +70,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0",
-                url = "https://oss.oracle.com/licenses/CDDL",
+                url = "https://oss.oracle.com/licenses/CDDL"
             )
         )
     )
@@ -58,7 +82,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1",
-                url = "https://www.gnu.org/licenses/lgpl-2.1",
+                url = "https://www.gnu.org/licenses/lgpl-2.1"
             )
         )
     )
@@ -70,7 +94,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU LESSER GENERAL PUBLIC LICENSE, Version 3.0",
-                url = "https://www.gnu.org/licenses/lgpl-3.0",
+                url = "https://www.gnu.org/licenses/lgpl-3.0"
             )
         )
     )
@@ -83,7 +107,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception",
-                url = "https://openjdk.java.net/legal/gplv2+ce.html",
+                url = "https://openjdk.java.net/legal/gplv2+ce.html"
             )
         )
     )
@@ -95,7 +119,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "Apache License 2.0",
-                url = "https://www.apache.org/licenses/LICENSE-2.0",
+                url = "https://www.apache.org/licenses/LICENSE-2.0"
             )
         )
     )
@@ -107,7 +131,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         licenses = listOf(
             OslcLicenseEntry(
                 license = "Aladin Free Public License",
-                url = "http://www.artifex.com/downloads/doc/Public.htm",
+                url = "http://www.artifex.com/downloads/doc/Public.htm"
             )
         )
     )
@@ -124,7 +148,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     row(depWithLGPL3, licenseLGPL3Name),
                     row(depWithGPLCE, null),
                     row(depWithAPL2, null),
-                    row(depWithAladin, licenseAlladinName),
+                    row(depWithAladin, licenseAlladinName)
                 ) { dep: OslcDependencyLicenseEntry, licenseName: String? ->
 
                     val output = OslcComplianceChecker.findAllMatchingLicenses(dep, true)
@@ -149,7 +173,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     row(depWithLGPL3, null),
                     row(depWithGPLCE, null),
                     row(depWithAPL2, null),
-                    row(depWithAladin, licenseAlladinName),
+                    row(depWithAladin, licenseAlladinName)
                 ) { dep: OslcDependencyLicenseEntry, licenseName: String? ->
                     val output = OslcComplianceChecker.findAllMatchingLicenses(dep, false)
                     println("Given: ${dep.licenses.joinToString { "[${it.license} - ${it.url}]" }}")
@@ -181,7 +205,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     "GNU Lesser General Public License 2.1" to 9,
                     "GNU General Public License 2.0" to 4,
                     "GNU General Public License 3.0" to 4,
-                    "Mozilla Public License 2.0" to 5
+                    MPL_LICENSE to 5
                 )
                 val notExpectedLicenses = listOf(
                     "Apache License 2.0",
@@ -218,7 +242,7 @@ class OslcComplianceCheckerTest : FunSpec() {
 
                 val expectedLicenses = mapOf(
                     "Alladin Free Public License 9" to 5,
-                    "Academic Free License 3.0" to 3,
+                    "Academic Free License 3.0" to 3
                 )
                 val notExpectedLicenses = listOf(
                     "Apache License 2.0",
@@ -235,7 +259,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                     "GNU Lesser General Public License 2.1",
                     "GNU General Public License 2.0",
                     "GNU General Public License 3.0",
-                    "Mozilla Public License 2.0"
+                    MPL_LICENSE
                 )
                 printDefinitions(definitions)
                 expectedLicenses.forEach { (license: String, numberOfAliases: Int) ->
@@ -282,7 +306,7 @@ class OslcComplianceCheckerTest : FunSpec() {
                 val epl2 = output.entries.firstOrNull { it.key.license == "Eclipse Public License 2.0" }
                 epl2 shouldNotBe null
                 epl2?.value?.size shouldBe 1
-                val mpl2 = output.entries.firstOrNull { it.key.license == "Mozilla Public License 2.0" }
+                val mpl2 = output.entries.firstOrNull { it.key.license == MPL_LICENSE }
                 mpl2 shouldNotBe null
                 mpl2?.value?.size shouldBe 1
                 val unknown = output.entries.firstOrNull { it.key.license == "UNKNOWN" }
@@ -310,6 +334,7 @@ class OslcComplianceCheckerTest : FunSpec() {
         }
     }
 }
+
 
 private fun printDefinitions(definitions: List<OslcLicenseDefinition>) {
     definitions.forEach {


### PR DESCRIPTION
## Warning: SonarQube scan is deprecated.
Last Sonar commit hash: 308a57e
Last Git commit hash: d9e36e8

### Rule Description: 
<p>Instead, use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a
single place.</p>

<h4>Noncompliant code example</h4>
<p>With the default threshold of 3:</p>
<pre data-diff-id="1" data-diff-type="noncompliant">
class A {
    fun run() {
        prepare("string literal")    // Noncompliant - "string literal" is duplicated 3 times
        execute("string literal")
        release("string literal")
    }

    fun method() {
        println("'")                 // Compliant - literal "'" has less than 5 characters and is excluded
        println("'")
        println("'")
    }
}
</pre>
<h4>Compliant solution</h4>
<pre data-diff-id="1" data-diff-type="compliant">
class A {
    companion object {
        const val CONSTANT = "string literal"
    }

    fun run() {
        prepare(CONSTANT)    // Compliant
        execute(CONSTANT)
        release(CONSTANT)
    }
}
</pre>
<p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
occurrences.</p>
<h3>Exceptions</h3>
<p>To prevent generating some false-positives, literals having 5 or less characters are excluded as well as literals containing only letters, digits
and '_'.</p>

### These files were changed in the pull request:
#### src/main/kotlin/de/deutschepost/sdm/cdlib/utils/HashUtils.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/git/RepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/release/report/internal/oslcComplianceChecker/OslcComplianceChecker.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/FnciReportTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NameResolverAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcComplianceCheckerTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/sharepoint/SharepointClient.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/report/OslcCompianceAcceptedListTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcNPMPluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/names/NamesCommandAzureTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/release/ReportOslcGradlePluginIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateCommandTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCloseIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/ChangeOslcIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeCreateIntegrationTest.kt
#### src/test/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/ChangeManagementRepositoryTest.kt
#### src/main/kotlin/de/deutschepost/sdm/cdlib/change/changemanagement/api/ChangeHandler.kt
